### PR TITLE
Show publish date under article subtitle

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,47 @@
+# TODO
+
+## Lift title and subtitle out of MDX into `metadata`
+
+Today, each article duplicates its header content:
+
+- `metadata.title` (in MDX) → drives `<title>` tag, og/twitter meta tags
+- `# Heading` (in MDX body) → drives the visible `<h1>` (mapped to `<Title>`)
+- `## Subheading` (in MDX body) → drives the visible `<h2>` (mapped to `<Lede>`)
+
+There is no `metadata.subtitle`. The two h1 sources happen to roughly match but are not linked, and several articles have a duplicated `" / Newt Interactive"` suffix in `metadata.title` that gets double-appended in `MdxLayout`.
+
+### Why lift it
+
+- Single source of truth for visible h1 vs SEO `<title>`.
+- Lets `MdxLayout` render the entire header (title, subtitle, dates) itself, removing the need for `ArticleDatesContext`.
+- `Lede` goes back to being a dumb component; the context file can be deleted.
+
+### Refactor steps
+
+1. Normalize each `metadata.title` to drop the ` / Newt Interactive` suffix (the layout already appends it).
+2. Add a new `metadata.subtitle` field to every article.
+3. Delete the `# ...` and `## ...` lines from every MDX body.
+4. In `components/MdxLayout/index.tsx`, render the header explicitly:
+   ```tsx
+   <ArticleContainer>
+     {metadata.series && <SeriesTitleLink ... />}
+     <Title>{metadata.title}</Title>
+     <Lede>{metadata.subtitle}</Lede>
+     {metadata.published && (
+       <ArticleDates published={metadata.published} updated={metadata.updated} />
+     )}
+     {children}
+   </ArticleContainer>
+   ```
+5. Update `pages/blocks/dna/index.tsx` (the only non-MDX article) to match the new pattern.
+6. Drop `h1`/`h2` mappings from `mdx-components.tsx` (or keep them in case body content ever uses them).
+7. Delete `components/ArticleDates/context.tsx` and the `useContext` in `Lede`.
+
+### Files affected
+
+- `components/MdxLayout/index.tsx`
+- `components/Lede/index.tsx`
+- `components/ArticleDates/context.tsx` (delete)
+- `mdx-components.tsx`
+- `pages/blocks/dna/index.tsx`
+- All 11 `.mdx` article files under `pages/blocks/` and `pages/series/` and `pages/notes/`

--- a/components/ArticleDates/context.tsx
+++ b/components/ArticleDates/context.tsx
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+
+export interface ArticleDatesContextValue {
+  published?: string;
+  updated?: string;
+}
+
+export const ArticleDatesContext = createContext<ArticleDatesContextValue>({});

--- a/components/ArticleDates/index.tsx
+++ b/components/ArticleDates/index.tsx
@@ -1,6 +1,5 @@
 interface ArticleDatesProps {
   published: string;
-  updated?: string;
 }
 
 const formatDate = (iso: string) => {

--- a/components/ArticleDates/index.tsx
+++ b/components/ArticleDates/index.tsx
@@ -1,0 +1,22 @@
+interface ArticleDatesProps {
+  published: string;
+  updated?: string;
+}
+
+const formatDate = (iso: string) => {
+  const [year, month, day] = iso.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+};
+
+const ArticleDates = ({ published }: ArticleDatesProps) => (
+  <p className="text-sm text-slate-400 font-light text-center mb-12 md:mb-16">
+    <time dateTime={published}>{formatDate(published)}</time>
+  </p>
+);
+
+export default ArticleDates;

--- a/components/Lede/index.tsx
+++ b/components/Lede/index.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+import { cn } from "../../lib/utils";
 import ArticleDates from "../ArticleDates";
 import { ArticleDatesContext } from "../ArticleDates/context";
 
@@ -7,15 +8,19 @@ interface Lede {
 }
 
 const Lede = ({ children }: Lede) => {
-  const { published, updated } = useContext(ArticleDatesContext);
-  const subtitleClasses = published
-    ? "text-lg text-slate-400 font-light justify-self-center self-center text-center mb-4 max-w-3xl md:text-xl"
-    : "text-lg text-slate-400 font-light justify-self-center self-center text-center mb-12 md:mb-16 max-w-3xl md:text-xl";
+  const { published } = useContext(ArticleDatesContext);
 
   return (
     <>
-      <h2 className={subtitleClasses}>{children}</h2>
-      {published && <ArticleDates published={published} updated={updated} />}
+      <h2
+        className={cn(
+          "text-lg text-slate-400 font-light justify-self-center self-center text-center max-w-3xl md:text-xl",
+          published ? "mb-4" : "mb-12 md:mb-16"
+        )}
+      >
+        {children}
+      </h2>
+      {published && <ArticleDates published={published} />}
     </>
   );
 };

--- a/components/Lede/index.tsx
+++ b/components/Lede/index.tsx
@@ -1,12 +1,22 @@
+import { useContext } from "react";
+import ArticleDates from "../ArticleDates";
+import { ArticleDatesContext } from "../ArticleDates/context";
+
 interface Lede {
   children: React.ReactNode;
 }
 
 const Lede = ({ children }: Lede) => {
+  const { published, updated } = useContext(ArticleDatesContext);
+  const subtitleClasses = published
+    ? "text-lg text-slate-400 font-light justify-self-center self-center text-center mb-4 max-w-3xl md:text-xl"
+    : "text-lg text-slate-400 font-light justify-self-center self-center text-center mb-12 md:mb-16 max-w-3xl md:text-xl";
+
   return (
-    <h2 className="text-lg text-slate-400 font-light justify-self-center self-center text-center mb-12 md:mb-16 max-w-3xl md:text-xl">
-      {children}
-    </h2>
+    <>
+      <h2 className={subtitleClasses}>{children}</h2>
+      {published && <ArticleDates published={published} updated={updated} />}
+    </>
   );
 };
 

--- a/components/MdxLayout/index.tsx
+++ b/components/MdxLayout/index.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import { ArticleContainer, Navbar } from "..";
 import { SeriesTitleLink } from "..";
+import { ArticleDatesContext } from "../ArticleDates/context";
 
 interface Metadata {
   title: string;
@@ -8,6 +9,8 @@ interface Metadata {
   keywords: string;
   ogImage: string;
   url: string;
+  published?: string;
+  updated?: string;
   series?: {
     name: string;
     href: string;
@@ -61,7 +64,14 @@ export default function MdxLayout({ children, metadata }: MdxLayoutProps) {
             seriesName={metadata.series?.name}
           />
         )}
-        {children}
+        <ArticleDatesContext.Provider
+          value={{
+            published: metadata.published,
+            updated: metadata.updated,
+          }}
+        >
+          {children}
+        </ArticleDatesContext.Provider>
       </ArticleContainer>
     </>
   );

--- a/components/index.ts
+++ b/components/index.ts
@@ -3,6 +3,7 @@ export {
   default as ArticleContainer,
   ArticleSection,
 } from "./ArticleContainer";
+export { default as ArticleDates } from "./ArticleDates";
 export { default as Button } from "./Button";
 export { Code, InlineCode } from "./Code";
 export { Checkbox } from "./Checkbox";

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -13,10 +13,10 @@ import Link from "next/link";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
-    h1: ({ children }) => <Title>{children}</Title>,
-    h2: ({ children }) => <Lede>{children}</Lede>,
-    h3: ({ children }) => <H2>{children}</H2>,
-    h4: ({ children }) => <H3>{children}</H3>,
+    h1: Title,
+    h2: Lede,
+    h3: H2,
+    h4: H3,
     blockquote: ({ children }) => <Quote>{children}</Quote>,
     p: ({ children }) => <Paragraph>{children}</Paragraph>,
     a: ({ children, href }) => (

--- a/pages/blocks/c1-ffl/index.mdx
+++ b/pages/blocks/c1-ffl/index.mdx
@@ -7,6 +7,8 @@ export const metadata = {
   keywords: "C1-FFL, coherent feed forward loop, biological circuits, regulatory networks, sign-sensitive delay, persistence detection, systems biology, gene regulation, interactive simulator, biological AND gate",
   ogImage: "https://i.postimg.cc/pTv2mX7M/c1-ffl-card.png",
   url: "https://newtinteractive.com/blocks/c1-ffl",
+  published: "2024-12-27",
+  updated: "2025-01-20",
 };
 
 # Coherent Type I Feed-Forward Loop

--- a/pages/blocks/circuit-evolution/index.mdx
+++ b/pages/blocks/circuit-evolution/index.mdx
@@ -7,6 +7,8 @@ export const metadata = {
   keywords: "circuit evolution, simulation, graph theory, probability",
   ogImage: "https://i.postimg.cc/8cnccDX7/circuit-evolution-img.png",
   url: "https://newtinteractive.com/blocks/circuit-evolution",
+  published: "2024-11-26",
+  updated: "2024-12-02",
 };
 
 export function InfoAccordion() {

--- a/pages/blocks/dna/index.tsx
+++ b/pages/blocks/dna/index.tsx
@@ -55,18 +55,18 @@ const DNAPage = () => {
       </Head>
       <Navbar />
       <ArticleContainer>
-        <Title>DNA in 3D</Title>
         <ArticleDatesContext.Provider value={{ published: "2022-01-09" }}>
+          <Title>DNA in 3D</Title>
           <Lede>A simplified model of a DNA molecule</Lede>
-        </ArticleDatesContext.Provider>
-        <div className="flex flex-col justify-center w-full mx-auto my-8 lg:flex-row lg:h-auto lg:my-12">
-          <div className="h-3/5 max-h-[600px] m-4 lg:h-[600px] lg:w-3/5">
-            <div className="h-full bg-slate-300">
-              <DNADoubleHelixCanvas />
+          <div className="flex flex-col justify-center w-full mx-auto my-8 lg:flex-row lg:h-auto lg:my-12">
+            <div className="h-3/5 max-h-[600px] m-4 lg:h-[600px] lg:w-3/5">
+              <div className="h-full bg-slate-300">
+                <DNADoubleHelixCanvas />
+              </div>
             </div>
           </div>
-        </div>
-        <PostArticleSubscribe />
+          <PostArticleSubscribe />
+        </ArticleDatesContext.Provider>
       </ArticleContainer>
     </>
   );

--- a/pages/blocks/dna/index.tsx
+++ b/pages/blocks/dna/index.tsx
@@ -7,6 +7,7 @@ import {
   PostArticleSubscribe,
   Title,
 } from "../../../components";
+import { ArticleDatesContext } from "../../../components/ArticleDates/context";
 
 const DNADoubleHelixCanvas = dynamic(
   () => import("../../../canvases/DNA-DoubleHelixCanvas"),
@@ -55,7 +56,9 @@ const DNAPage = () => {
       <Navbar />
       <ArticleContainer>
         <Title>DNA in 3D</Title>
-        <Lede>A simplified model of a DNA molecule</Lede>
+        <ArticleDatesContext.Provider value={{ published: "2022-01-09" }}>
+          <Lede>A simplified model of a DNA molecule</Lede>
+        </ArticleDatesContext.Provider>
         <div className="flex flex-col justify-center w-full mx-auto my-8 lg:flex-row lg:h-auto lg:my-12">
           <div className="h-3/5 max-h-[600px] m-4 lg:h-[600px] lg:w-3/5">
             <div className="h-full bg-slate-300">

--- a/pages/blocks/erdos-renyi-graph/index.mdx
+++ b/pages/blocks/erdos-renyi-graph/index.mdx
@@ -7,6 +7,7 @@ export const metadata = {
   keywords: "Erdős-Rényi graphs, random networks, graph theory, probability",
   ogImage: "https://i.ibb.co/0jWX5dr/circle-in-a-circle-kandinsky.jpg",
   url: "https://newtinteractive.com/blocks/erdos-renyi-graph",
+  published: "2024-10-30",
 };
 
 # Erdős-Rényi Graphs

--- a/pages/blocks/kalman-filters/index.mdx
+++ b/pages/blocks/kalman-filters/index.mdx
@@ -8,6 +8,7 @@ export const metadata = {
   keywords: "Kalman filters, uncertainty, predictions, continuous environment, algorithm, interactive explainer",
   ogImage: "https://i.ibb.co/NpXN5rj/Meta-tag-image-1.png",
   url: "https://newtinteractive.com/blocks/kalman-filters",
+  published: "2022-01-23",
 };
 
 # Kalman Filters

--- a/pages/blocks/robot-localization/index.mdx
+++ b/pages/blocks/robot-localization/index.mdx
@@ -8,6 +8,7 @@ export const metadata = {
   keywords: "robot localization, interactive explainer, sensing, movement, algorithm, robotics",
   ogImage: "https://i.ibb.co/NpXN5rj/Meta-tag-image-1.png",
   url: "https://newtinteractive.com/blocks/robot-localization",
+  published: "2022-01-09",
 };
 
 # Simple Robot Localization

--- a/pages/notes/threejs-journey/index.mdx
+++ b/pages/notes/threejs-journey/index.mdx
@@ -9,6 +9,8 @@ export const metadata = {
   keywords: "ThreeJS, 3D graphics, web development, animations, cameras, shaders, interactive learning",
   ogImage: "https://i.ibb.co/NpXN5rj/Meta-tag-image-1.png",
   url: "https://www.newtinteractive.com/notes/threejs-journey",
+  published: "2022-02-08",
+  updated: "2024-07-31",
 };
 
 # ThreeJS Journey Notes

--- a/pages/series/systems-biology/autoregulation-1.mdx
+++ b/pages/series/systems-biology/autoregulation-1.mdx
@@ -11,6 +11,8 @@ export const metadata = {
   keywords: "network motifs, random networks, autoregulation, gene expression, transcription factors, systems biology, cell signaling",
   ogImage: "https://i.ibb.co/Nnbfc6y/genetic-circuit.png",
   url: "https://newtinteractive.com/series/systems-biology/autoregulation-1",
+  published: "2024-11-02",
+  updated: "2024-12-15",
   series: {
     name: "Systems Biology",
     href: "/series/systems-biology",

--- a/pages/series/systems-biology/autoregulation-2.mdx
+++ b/pages/series/systems-biology/autoregulation-2.mdx
@@ -11,6 +11,7 @@ export const metadata = {
   keywords: "network motifs, random networks, autoregulation, gene expression, transcription factors, systems biology, cell signaling",
   ogImage: "https://i.ibb.co/Nnbfc6y/genetic-circuit.png",
   url: "https://newtinteractive.com/series/systems-biology/autoregulation-2",
+  published: "2024-12-15",
   series: {
     name: "Systems Biology",
     href: "/series/systems-biology",

--- a/pages/series/systems-biology/transcription-network-basics-1.mdx
+++ b/pages/series/systems-biology/transcription-network-basics-1.mdx
@@ -9,6 +9,8 @@ export const metadata = {
   keywords: "transcription networks, gene expression, transcription factors, systems biology, cell signaling",
   ogImage: "https://i.ibb.co/Nnbfc6y/genetic-circuit.png",
   url: "https://newtinteractive.com/series/systems-biology/transcription-network-basics-1",
+  published: "2024-09-26",
+  updated: "2024-09-28",
   series: {
     name: "Systems Biology",
     href: "/series/systems-biology",

--- a/pages/series/systems-biology/transcription-network-basics-2.mdx
+++ b/pages/series/systems-biology/transcription-network-basics-2.mdx
@@ -10,6 +10,7 @@ export const metadata = {
   keywords: "transcription factors, gene expression, activators, repressors, Hill function, systems biology, mathematical modeling",
   ogImage: "https://i.ibb.co/Nnbfc6y/genetic-circuit.png",
   url: "https://newtinteractive.com/series/systems-biology/transcription-network-basics-2",
+  published: "2024-10-06",
   series: {
     name: "Systems Biology",
     href: "/series/systems-biology",

--- a/pages/series/systems-biology/transcription-network-basics-3.mdx
+++ b/pages/series/systems-biology/transcription-network-basics-3.mdx
@@ -7,6 +7,8 @@ export const metadata = {
   keywords: "transcription networks, dynamics, response time, systems biology",
   ogImage: "https://i.ibb.co/Nnbfc6y/genetic-circuit.png",
   url: "https://newtinteractive.com/series/systems-biology/transcription-network-basics-3",
+  published: "2024-10-27",
+  updated: "2024-11-06",
   series: {
     name: "Systems Biology",
     href: "/series/systems-biology",


### PR DESCRIPTION
## Summary
- Adds a centered publish date line under each article's subtitle, sourced from a new `published` field in `metadata`.
- New `<ArticleDates>` component plus a tiny `ArticleDatesContext` so `MdxLayout` can pass dates down to `<Lede>` (which needs to render alongside the MDX-compiled subtitle).
- All 12 articles get accurate publish dates derived from PR merge dates (modern era) or last meaningful content commits (pre-PR articles). `updated` is also stored in metadata for several articles but intentionally not rendered in the UI yet.
- `TODO.md` notes a follow-up refactor: lift title/subtitle out of MDX into metadata so the context layer can be removed.

## Test plan
- [ ] Click through each article and confirm the date renders centered under the subtitle
- [ ] Spacing between subtitle and date looks right at desktop and mobile widths
- [ ] DNA page (the only non-MDX article) renders the date with consistent spacing
- [ ] No regression in `<title>` / og:title tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)