### PR TITLE
Add article-export tooling for interactive essays

### DIFF
--- a/scripts/article-export/README.md
+++ b/scripts/article-export/README.md
@@ -1,0 +1,92 @@
+# article-export
+
+Turn an interactive newt essay into a **Substack-ready markdown doc** plus a
+folder of **static figure screenshots** — for newsletters, cross-posts, and
+other places that can't run the live interactives.
+
+```bash
+# 1. make sure the dev server is up
+npm run dev
+
+# 2. one command: extract prose + shoot every figure + link captions
+node scripts/article-export/cli.mjs all hemoglobin
+```
+
+Output lands in `docs/<slug>/export/`:
+
+```
+docs/hemoglobin/export/
+  essay.md          # prose, footnotes at the bottom, image placeholders
+  figures.json      # manifest (one entry per figure)
+  figures/          # NN-name.png, retina, ≤1400px wide, 28px white margin
+```
+
+## What it does
+
+Two halves that share an ordered **figure manifest**:
+
+- **`extract`** reads `pages/essays/<slug>/index.mdx` and produces the markdown:
+  - `TippyTooltip` footnotes → `[^n]` markers collected under `## Footnotes`
+  - `Term` wrappers stripped, `<H2>` → `##`, `&mdash;`/`<sub>` normalized
+  - every block-level figure component → a placeholder:
+    `> **[Image — `02-iron.png`]** alt text`
+  - the subscribe/CTA blocks dropped
+- **`shoot`** boots a headless page, finds every `<figure>` in document order,
+  and screenshots each — 3D (Mol* / react-three-fiber), morph **players**
+  (canvas + play/slider, captured at frame 0), and 2D charts (default state),
+  all handled automatically.
+- **`link`** (folded into `all`) writes each figure's rendered caption back into
+  its placeholder's alt text.
+
+The linchpin: every interactive renders as a `<figure>`, and the MDX components
+map to those `<figure>`s 1:1 in order — so prose placeholders and screenshots
+line up automatically, no per-figure wiring.
+
+## Commands
+
+| Command | Needs dev server | Does |
+|---|---|---|
+| `extract <slug>` | no | MDX → `essay.md` + `figures.json` |
+| `shoot <slug>`   | yes | screenshot figures from an existing manifest |
+| `all <slug>`     | yes | extract → shoot → link (the usual one) |
+
+Flags: `--out <dir>`, `--base-url <url>` (default `http://localhost:3000`),
+`--pad <px>` (default 28), `--max-width <px>` (default 1400), `--port <n>`.
+
+## Per-essay overrides
+
+Optional `pages/essays/<slug>/export.config.json`, keyed by generated filename:
+
+```json
+{
+  "figures": {
+    "02-iron.png": { "alt": "A single ferrous iron ion at the center of the heme." },
+    "10-binding-morph.png": { "alt": "…", "frame": 0 }
+  }
+}
+```
+
+- `alt` — overrides the placeholder alt (beats have no figcaption, so a hand
+  alt reads better). Otherwise: figcaption › a guess from the component name.
+- `frame` — drive a morph player's slider to a frame before capture.
+
+## Tuning the component vocabulary
+
+`rules.mjs` is the one place that knows newt's components (footnote/term/heading
+components, drop-blocks, figure naming props). Edit it there if the shared essay
+components change.
+
+## How the screenshots work (the headless gotcha)
+
+Headless Chrome drops GPU-composited canvas layers (WebGL) from normal
+screenshots. The fix, baked into `capture.mjs`: launch with software GL
+(SwiftShader) + `--disable-gpu-compositing`, and capture with
+`captureBeyondViewport`. Then WebGL figures composite into a plain screenshot
+like any other DOM — no canvas-readback tricks needed. Mol* renders its canvas
+at 1×, so the capture briefly nudges it to 2× for retina output.
+
+## Requirements
+
+- Node ≥ 21 (uses the built-in global `WebSocket`)
+- Google Chrome (override path with `CHROME_BIN`)
+- `sharp` (already a dependency) for padding/downscaling

--- a/scripts/article-export/capture.mjs
+++ b/scripts/article-export/capture.mjs
@@ -1,0 +1,276 @@
+// Reusable headless-Chrome capture core for the article-export toolkit.
+//
+// The hard-won bit: headless Chrome drops GPU-composited canvas layers (WebGL,
+// accelerated 2D) from normal screenshots. Launching with software GL
+// (SwiftShader) + software compositing, and capturing with
+// `captureBeyondViewport`, makes the WebGL figures (Mol*, react-three-fiber)
+// composite into the screenshot like any other DOM. So a plain element
+// screenshot works for 3D and 2D figures alike.
+//
+// Everything here is generic — no per-essay or per-figure knowledge. The newt
+// vocabulary lives in rules.mjs; the orchestration in shoot.mjs.
+
+import { spawn } from "node:child_process";
+
+const CHROME =
+  process.env.CHROME_BIN ||
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+// Layout viewport + pixel density for every capture. dsf 2 → retina output.
+export const VIEW = { width: 1280, height: 2400, dsf: 2 };
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- Chrome process -------------------------------------------------------
+
+export async function launchChrome({ port = 9222, userDataDir } = {}) {
+  const dir = userDataDir || `/tmp/article-export-chrome-${port}`;
+  const proc = spawn(
+    CHROME,
+    [
+      `--remote-debugging-port=${port}`,
+      `--user-data-dir=${dir}`,
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-extensions",
+      "--headless=new",
+      "--hide-scrollbars",
+      // WebGL via SwiftShader + software compositing → screenshots capture it.
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--disable-gpu-compositing",
+      "about:blank",
+    ],
+    { stdio: "ignore", detached: false }
+  );
+  // Wait for the DevTools endpoint to come up.
+  const base = `http://127.0.0.1:${port}`;
+  for (let i = 0; i < 50; i++) {
+    try {
+      const r = await fetch(`${base}/json/version`);
+      if (r.ok) return { proc, port, base };
+    } catch {}
+    await sleep(200);
+  }
+  proc.kill();
+  throw new Error("Chrome DevTools endpoint did not come up");
+}
+
+// --- CDP client (direct page-target websocket; no session routing) --------
+
+class CDP {
+  constructor(ws) {
+    this.ws = ws;
+    this.id = 0;
+    this.pending = new Map();
+    this.handlers = [];
+  }
+  static async connect(wsUrl) {
+    const ws = new WebSocket(wsUrl);
+    await new Promise((res, rej) => {
+      ws.onopen = res;
+      ws.onerror = () => rej(new Error("CDP websocket error"));
+    });
+    const cdp = new CDP(ws);
+    ws.onmessage = (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.id && cdp.pending.has(msg.id)) {
+        const { resolve, reject } = cdp.pending.get(msg.id);
+        cdp.pending.delete(msg.id);
+        msg.error ? reject(new Error(JSON.stringify(msg.error))) : resolve(msg.result);
+      } else if (msg.method) {
+        cdp.handlers.forEach((h) => h(msg));
+      }
+    };
+    return cdp;
+  }
+  send(method, params = {}) {
+    const id = ++this.id;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  on(fn) {
+    this.handlers.push(fn);
+  }
+  close() {
+    try { this.ws.close(); } catch {}
+  }
+}
+
+// --- Page --------------------------------------------------------------------
+
+export class Page {
+  constructor(cdp) {
+    this.cdp = cdp;
+  }
+
+  static async open(port, url) {
+    const base = `http://127.0.0.1:${port}`;
+    const res = await fetch(`${base}/json/new?${url}`, { method: "PUT" });
+    const target = await res.json();
+    const cdp = await CDP.connect(target.webSocketDebuggerUrl);
+    await cdp.send("Page.enable");
+    await cdp.send("Runtime.enable");
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: VIEW.width,
+      height: VIEW.height,
+      deviceScaleFactor: VIEW.dsf,
+      mobile: false,
+    });
+    const page = new Page(cdp);
+    await page.waitForLoad(url);
+    return page;
+  }
+
+  async waitForLoad(url) {
+    const loaded = new Promise((res) =>
+      this.cdp.on((m) => m.method === "Page.loadEventFired" && res())
+    );
+    await this.cdp.send("Page.navigate", { url });
+    await Promise.race([loaded, sleep(10000)]);
+    await sleep(1200);
+  }
+
+  async eval(expr) {
+    const r = await this.cdp.send("Runtime.evaluate", {
+      expression: expr,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (r.exceptionDetails) throw new Error(JSON.stringify(r.exceptionDetails));
+    return r.result.value;
+  }
+
+  async captureClip({ x, y, width, height }) {
+    const shot = await this.cdp.send("Page.captureScreenshot", {
+      format: "png",
+      captureBeyondViewport: true,
+      clip: { x, y, width, height, scale: 1 },
+    });
+    return Buffer.from(shot.data, "base64");
+  }
+
+  close() {
+    this.cdp.close();
+  }
+}
+
+// --- Figure discovery (generic: every <figure> in document order) ---------
+
+// A small in-page helper, shared by discovery and capture, that decides when a
+// figure has finished rendering: any WebGL canvas has drawn content, and any
+// player control (a disabled-until-ready slider) has become enabled.
+const READINESS_HELPERS = `
+  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+  const hasContent = (c) => {
+    try {
+      const t = document.createElement("canvas");
+      t.width = Math.min(c.width, 240); t.height = Math.min(c.height, 140);
+      const g = t.getContext("2d");
+      g.drawImage(c, 0, 0, t.width, t.height);
+      const d = g.getImageData(0, 0, t.width, t.height).data;
+      let nw = 0;
+      for (let i = 0; i < d.length; i += 4)
+        if (d[i] < 248 || d[i+1] < 248 || d[i+2] < 248) nw++;
+      return nw > 40;
+    } catch (e) { return false; }
+  };
+`;
+
+export async function discoverFigures(page) {
+  return page.eval(`(() => {
+    return [...document.querySelectorAll("figure")].map((f, i) => {
+      const cap = f.querySelector("figcaption");
+      return {
+        index: i,
+        caption: cap ? cap.textContent.trim() : null,
+        hasCanvas: !!f.querySelector("canvas"),
+        hasRange: !!f.querySelector('input[type="range"]'),
+        buttons: f.querySelectorAll("button").length,
+        hasSvg: !!f.querySelector("svg"),
+      };
+    });
+  })()`);
+}
+
+// Capture one figure (by document-order index) as a padded, width-capped PNG.
+// Works for 3D (canvas + gizmo), morph players (canvas + controls), and 2D
+// (SVG/charts). `frame` (a number) drives a morph slider; omit to keep the
+// figure's default interactive state. The capture region is the figure's first
+// child div — the visual content, excluding any sibling <figcaption>.
+export async function captureFigure(
+  page,
+  index,
+  { pad = 28, maxWidth = 1400, frame = null, waitMs = 12000 } = {}
+) {
+  const info = await page.eval(`(async () => {
+    ${READINESS_HELPERS}
+    const figs = [...document.querySelectorAll("figure")];
+    const fig = figs[${index}];
+    if (!fig) return JSON.stringify({ error: "no-figure" });
+    const el = fig.querySelector(":scope > div") || fig;
+    el.scrollIntoView({ block: "center" });
+    await sleep(400);
+    // Wait until ready: canvas drawn (if any) and slider enabled (if any).
+    const t0 = Date.now();
+    while (Date.now() - t0 < ${waitMs}) {
+      const canvas = el.querySelector("canvas");
+      const sld = el.querySelector('input[type="range"]');
+      const ready = !sld || !sld.disabled;
+      const drawn = !canvas || hasContent(canvas);
+      if (ready && drawn) break;
+      await sleep(300);
+    }
+    // Retina: nudge the WebGL canvas to ~2x its CSS size (Mol* boots at 1x).
+    const cvs = el.querySelector("canvas");
+    if (cvs) {
+      const cssW = cvs.clientWidth;
+      let n = 0;
+      while (cvs.width < cssW * 2 * 0.95 && n < 25) {
+        window.dispatchEvent(new Event("resize"));
+        await sleep(250); n++;
+      }
+      await sleep(900);
+    }
+    // Optional: drive a morph slider to a frame; otherwise keep default state.
+    const frame = ${frame === null ? "null" : Number(frame)};
+    const sld = el.querySelector('input[type="range"]');
+    if (frame !== null && sld && !sld.disabled) {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype, "value").set;
+      setter.call(sld, String(frame));
+      sld.dispatchEvent(new Event("input", { bubbles: true }));
+      sld.dispatchEvent(new Event("change", { bubbles: true }));
+      await sleep(900);
+    }
+    el.querySelectorAll('[class*="msp-toast"]').forEach((e) => { e.style.display = "none"; });
+    await sleep(500);
+    const r = el.getBoundingClientRect();
+    return JSON.stringify({
+      x: r.x + window.scrollX, y: r.y + window.scrollY,
+      width: r.width, height: r.height,
+      // Detected now (post-boot) so the kind is accurate for lazy 3D figures.
+      hasCanvas: !!el.querySelector("canvas"),
+      hasRange: !!el.querySelector('input[type="range"]'),
+    });
+  })()`);
+  const rect = JSON.parse(info);
+  if (rect.error) throw new Error(`captureFigure[${index}]: ${rect.error}`);
+
+  let buf = await page.captureClip(rect);
+  const sharp = (await import("sharp")).default;
+  const p = pad * VIEW.dsf; // capture is at dsf, so pad in device px
+  buf = await sharp(buf)
+    .extend({ top: p, bottom: p, left: p, right: p, background: "#ffffff" })
+    .png()
+    .toBuffer();
+  let w = buf.readUInt32BE(16);
+  if (maxWidth && w > maxWidth) {
+    buf = await sharp(buf).resize({ width: maxWidth }).png().toBuffer();
+  }
+  const kind = rect.hasCanvas ? (rect.hasRange ? "player" : "3d") : "2d";
+  return { buf, kind };
+}

--- a/scripts/article-export/cli.mjs
+++ b/scripts/article-export/cli.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// article-export — turn an interactive newt essay into a Substack-ready
+// markdown doc plus a folder of static figure screenshots.
+//
+//   node scripts/article-export/cli.mjs <command> <essay-slug> [flags]
+//
+// Commands:
+//   extract  MDX -> markdown doc + figures.json manifest (no browser)
+//   shoot    screenshot every figure listed in the manifest (needs dev server)
+//   all      extract, shoot, then link captions into the doc (the usual one)
+//   link     re-apply captions/overrides to the doc from the manifest (no browser)
+//
+// Flags:
+//   --out <dir>        output dir (default docs/<slug>/export)
+//   --base-url <url>   dev server (default http://localhost:3000)
+//   --pad <px>         white margin around each figure (default 28)
+//   --max-width <px>   downscale cap (default 1400)
+//   --port <n>         Chrome debug port (default 9222)
+
+import fs from "node:fs";
+import path from "node:path";
+import { extractEssay, loadOverrides } from "./extract.mjs";
+import { shootFigures, linkCaptions } from "./shoot.mjs";
+
+function parseFlags(args) {
+  const o = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith("--")) o[args[i].slice(2)] = args[i + 1], i++;
+  }
+  return o;
+}
+
+const [cmd, slug, ...rest] = process.argv.slice(2);
+if (!cmd || !slug || cmd === "--help") {
+  console.log(
+    "usage: node scripts/article-export/cli.mjs <extract|shoot|all> <essay-slug> [--out dir] [--base-url url] [--pad px] [--max-width px]"
+  );
+  process.exit(cmd ? 0 : 1);
+}
+
+const flags = parseFlags(rest);
+const root = process.cwd();
+const outDir = path.resolve(flags.out || path.join("docs", slug, "export"));
+const figuresDir = path.join(outDir, "figures");
+const docPath = path.join(outDir, "essay.md");
+const manifestPath = path.join(outDir, "figures.json");
+const shootOpts = {
+  outDir: figuresDir,
+  baseUrl: flags["base-url"] || "http://localhost:3000",
+  port: Number(flags.port || 9222),
+  pad: Number(flags.pad || 28),
+  maxWidth: Number(flags["max-width"] || 1400),
+  log: (m) => console.log(m),
+};
+
+function writeManifest(figures, route) {
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(manifestPath, JSON.stringify({ slug, route, figures }, null, 2) + "\n");
+}
+
+async function main() {
+  if (cmd === "extract" || cmd === "all") {
+    const { markdown, figures, route } = extractEssay(slug, { repoRoot: root });
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(docPath, markdown);
+    writeManifest(figures, route);
+    console.log(`extracted → ${path.relative(root, docPath)} (${figures.length} figures)`);
+    if (cmd === "extract") return;
+
+    const shot = await shootFigures({ route, figures, ...shootOpts });
+    const linked = linkCaptions(markdown, shot, loadOverrides(root, slug));
+    fs.writeFileSync(docPath, linked);
+    writeManifest(shot, route);
+    console.log(`\ndone → ${path.relative(root, outDir)}/  (doc + ${shot.length} figures)`);
+    return;
+  }
+
+  if (cmd === "shoot") {
+    if (!fs.existsSync(manifestPath)) {
+      console.error(`No manifest at ${manifestPath}. Run \`extract\` first.`);
+      process.exit(1);
+    }
+    const { route, figures } = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    const shot = await shootFigures({ route, figures, ...shootOpts });
+    writeManifest(shot, route);
+    // refresh captions in an existing doc if present
+    if (fs.existsSync(docPath)) {
+      const linked = linkCaptions(fs.readFileSync(docPath, "utf8"), shot, loadOverrides(root, slug));
+      fs.writeFileSync(docPath, linked);
+    }
+    console.log(`\nshot ${shot.length} figures → ${path.relative(root, figuresDir)}/`);
+    return;
+  }
+
+  if (cmd === "link") {
+    if (!fs.existsSync(manifestPath) || !fs.existsSync(docPath)) {
+      console.error(`Need an existing ${path.relative(root, docPath)} + manifest. Run \`all\` first.`);
+      process.exit(1);
+    }
+    const { figures } = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    const linked = linkCaptions(fs.readFileSync(docPath, "utf8"), figures, loadOverrides(root, slug));
+    fs.writeFileSync(docPath, linked);
+    console.log(`relinked alt text → ${path.relative(root, docPath)}`);
+    return;
+  }
+
+  console.error(`unknown command: ${cmd}`);
+  process.exit(1);
+}
+
+main().catch((e) => {
+  console.error("error:", e.message || e);
+  process.exit(1);
+});

--- a/scripts/article-export/extract.mjs
+++ b/scripts/article-export/extract.mjs
@@ -1,0 +1,254 @@
+// MDX essay -> Substack-ready markdown: footnotes pulled to the bottom, every
+// interactive figure replaced by a labelled image placeholder, prose kept
+// verbatim. Tuned to the newt component vocabulary in rules.mjs.
+//
+// Returns { markdown, figures } where `figures` is the ordered manifest the
+// shooter and linker consume (one entry per <figure> the essay renders).
+
+import fs from "node:fs";
+import path from "node:path";
+import { RULES, SUBSCRIPTS } from "./rules.mjs";
+
+const kebab = (s) =>
+  String(s)
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^A-Za-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+
+const humanize = (name) =>
+  name.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/Figure$|Block$/, "").trim();
+
+// --- tiny JSX scanners -----------------------------------------------------
+
+// Parse a JSX open tag starting at `start` ('<'). Tracks {} depth so a `>`
+// inside a `prop={<Foo>…</Foo>}` value doesn't end the tag early.
+function parseOpenTag(text, start) {
+  let depth = 0;
+  for (let i = start + 1; i < text.length; i++) {
+    const c = text[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    else if (c === ">" && depth === 0) {
+      const selfClosing = text[i - 1] === "/";
+      const attrsText = text.slice(start, selfClosing ? i - 1 : i);
+      return { attrsText, end: i + 1, selfClosing };
+    }
+  }
+  throw new Error("unterminated JSX tag at " + start);
+}
+
+// Read a brace-balanced `content={ … }` value out of an open tag's attr text,
+// stripping the <TippyTooltipContent> wrapper to leave the footnote body.
+function readContentBody(attrsText) {
+  const at = attrsText.indexOf("content=");
+  if (at === -1) return "";
+  const open = attrsText.indexOf("{", at);
+  if (open === -1) return "";
+  let depth = 0, j = open;
+  for (; j < attrsText.length; j++) {
+    if (attrsText[j] === "{") depth++;
+    else if (attrsText[j] === "}" && --depth === 0) break;
+  }
+  const cc = RULES.footnote.contentComponent;
+  return attrsText
+    .slice(open + 1, j)
+    .replace(new RegExp(`^\\s*<${cc}>`), "")
+    .replace(new RegExp(`</${cc}>\\s*$`), "")
+    .trim();
+}
+
+// --- transforms ------------------------------------------------------------
+
+function stripScaffolding(src) {
+  // import statements (possibly multi-line, terminated by ;)
+  src = src.replace(/^import\b[\s\S]*?;\s*\n/gm, "");
+  // {/* comments */}
+  src = src.replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+  // export const metadata = { … };  and  export default function … { … }
+  src = removeBalanced(src, /export const metadata\s*=\s*\{/);
+  src = removeBalanced(src, /export default function[\s\S]*?\{/, { fromBraceOpen: true });
+  return src;
+}
+
+// Remove a `{ … }`-balanced block whose start matches `startRe`.
+function removeBalanced(src, startRe, { fromBraceOpen = false } = {}) {
+  const m = startRe.exec(src);
+  if (!m) return src;
+  const braceStart = fromBraceOpen ? src.indexOf("{", m.index) : m.index + m[0].length - 1;
+  let depth = 0, i = braceStart;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}" && --depth === 0) { i++; break; }
+  }
+  // also swallow a trailing ; and newline
+  while (src[i] === ";" || src[i] === "\n" || src[i] === " ") i++;
+  return src.slice(0, m.index) + src.slice(i);
+}
+
+function unwrapInline(src) {
+  for (const name of RULES.unwrapInline) {
+    src = src.replace(new RegExp(`<${name}\\b[^>]*>([\\s\\S]*?)</${name}>`, "g"), "$1");
+  }
+  return src;
+}
+
+function applyHeadings(src) {
+  for (const [name, hashes] of Object.entries(RULES.headings)) {
+    src = src.replace(
+      new RegExp(`<${name}\\b[^>]*>([\\s\\S]*?)</${name}>`, "g"),
+      `\n${hashes} $1\n`
+    );
+  }
+  return src;
+}
+
+// Replace footnote tooltips with [^n] markers (collect bodies); collapse any
+// non-footnote tooltips to their anchor text. Single pass so nested `>` in the
+// content attr never trips a regex.
+function extractFootnotes(text) {
+  const TAG = "<" + RULES.footnote.component;
+  const CLOSE = "</" + RULES.footnote.component + ">";
+  const isFootnote = new RegExp(
+    `${RULES.footnote.variantAttr}\\s*=\\s*["']${RULES.footnote.variantValue}["']`
+  );
+  const footnotes = [];
+  let out = "", i = 0;
+  while (true) {
+    const start = text.indexOf(TAG, i);
+    if (start === -1) { out += text.slice(i); break; }
+    // Only treat as a component start if followed by space/＞/newline (not e.g. TippyTooltipContent)
+    const after = text[start + TAG.length];
+    if (!/[\s/>]/.test(after)) { out += text.slice(i, start + TAG.length); i = start + TAG.length; continue; }
+    out += text.slice(i, start);
+    const tag = parseOpenTag(text, start);
+    const foot = isFootnote.test(tag.attrsText);
+    let anchor = "", end = tag.end;
+    if (!tag.selfClosing) {
+      const ci = text.indexOf(CLOSE, tag.end);
+      anchor = text.slice(tag.end, ci);
+      end = ci + CLOSE.length;
+    }
+    if (foot) {
+      footnotes.push(readContentBody(tag.attrsText));
+      out += `${anchor}[^${footnotes.length}]`;
+    } else {
+      out += anchor; // non-footnote tooltip → keep its anchor text
+    }
+    i = end;
+  }
+  return { text: out, footnotes };
+}
+
+function parseProps(attrsAfterName) {
+  const props = {};
+  const re = /(\w+)\s*=\s*("([^"]*)"|'([^']*)'|\{([\s\S]*?)\})/g;
+  let m;
+  while ((m = re.exec(attrsAfterName))) {
+    props[m[1]] =
+      m[3] ?? m[4] ?? (m[5] !== undefined ? `{${m[5].trim()}}` : "");
+  }
+  return props;
+}
+
+function figureBaseName(name, props) {
+  for (const p of RULES.figureNameProps) {
+    const v = props[p];
+    if (v && !v.startsWith("{")) return kebab(v);
+  }
+  for (const v of Object.values(props)) {
+    if (v.startsWith("{")) {
+      const id = v.slice(1, -1).trim();
+      const mm = /([A-Z][A-Z0-9_]{2,})/.exec(id);
+      if (mm) return kebab(mm[1].replace(/_URL$/, "").toLowerCase());
+    }
+  }
+  return kebab(name);
+}
+
+// Replace every block-level capitalized component with an image placeholder,
+// building the ordered figure manifest. Drop CTA/layout blocks entirely.
+function extractFigures(text, overrides) {
+  const figures = [];
+  let out = "", i = 0;
+  while (i < text.length) {
+    const lt = text.indexOf("<", i);
+    if (lt === -1) { out += text.slice(i); break; }
+    const m = /^<([A-Z][A-Za-z0-9]*)/.exec(text.slice(lt, lt + 48));
+    const lineStart = text.lastIndexOf("\n", lt) + 1;
+    const blockLevel = text.slice(lineStart, lt).trim() === "";
+    if (!m || !blockLevel) { out += text.slice(i, lt + 1); i = lt + 1; continue; }
+    const name = m[1];
+    const tag = parseOpenTag(text, lt);
+    let end = tag.end;
+    if (!tag.selfClosing) {
+      const ci = text.indexOf(`</${name}>`, tag.end);
+      end = ci === -1 ? tag.end : ci + name.length + 3;
+    }
+    out += text.slice(i, lineStart);
+    if (!RULES.dropBlock.includes(name)) {
+      const props = parseProps(tag.attrsText.slice(1 + name.length));
+      const index = figures.length;
+      const file = `${String(index + 1).padStart(2, "0")}-${figureBaseName(name, props)}.png`;
+      const ov = overrides.figures?.[file] || {};
+      const base = humanize(name);
+      const provisional =
+        ov.alt ||
+        (props.caption && !props.caption.startsWith("{") ? props.caption : null) ||
+        (figureBaseName(name, props) !== kebab(name)
+          ? `${base}: ${figureBaseName(name, props).replace(/-/g, " ")}`
+          : base);
+      figures.push({ index, component: name, props, file, alt: provisional, frame: ov.frame ?? null });
+      out += `> **[Image — \`${file}\`]** ${provisional}\n`;
+    }
+    i = end;
+  }
+  return { text: out, figures };
+}
+
+function normalizeEntities(src) {
+  for (const [k, v] of Object.entries(RULES.entities)) src = src.split(k).join(v);
+  if (RULES.subscriptDigits) {
+    src = src.replace(/<sub>(\d+)<\/sub>/g, (_, d) =>
+      [...d].map((c) => SUBSCRIPTS[c] || c).join("")
+    );
+  }
+  return src;
+}
+
+const tidy = (src) => src.replace(/\n{3,}/g, "\n\n").replace(/[ \t]+\n/g, "\n").trim() + "\n";
+
+function assemble(body, footnotes) {
+  if (!footnotes.length) return tidy(body);
+  const notes = footnotes.map((b, i) => `[^${i + 1}]: ${b}`).join("\n\n");
+  return tidy(body) + `\n\n---\n\n## Footnotes\n\n${notes}\n`;
+}
+
+// --- public API ------------------------------------------------------------
+
+export function loadOverrides(root, slug) {
+  const p = path.join(root, "pages/essays", slug, "export.config.json");
+  try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return {}; }
+}
+
+export function extractEssay(slug, { repoRoot = process.cwd() } = {}) {
+  const mdxPath = path.join(repoRoot, RULES.mdxPathFor(slug));
+  let src = fs.readFileSync(mdxPath, "utf8");
+  const overrides = loadOverrides(repoRoot, slug);
+
+  src = stripScaffolding(src);
+  src = unwrapInline(src);
+  src = applyHeadings(src);
+  const fn = extractFootnotes(src);
+  src = fn.text;
+  const fig = extractFigures(src, overrides);
+  src = fig.text;
+  src = normalizeEntities(src);
+
+  return {
+    markdown: assemble(src, fn.footnotes),
+    figures: fig.figures,
+    footnotes: fn.footnotes,
+    route: RULES.routeFor(slug),
+  };
+}

--- a/scripts/article-export/rules.mjs
+++ b/scripts/article-export/rules.mjs
@@ -1,0 +1,57 @@
+// The newt-interactive component vocabulary the extractor understands. This is
+// the one file to edit if the shared essay components change. Everything else in
+// the toolkit is generic.
+
+export const RULES = {
+  // Where an essay's source and dev route live, given its slug.
+  mdxPathFor: (slug) => `pages/essays/${slug}/index.mdx`,
+  routeFor: (slug) => `/essays/${slug}`,
+
+  // Inline components whose wrapper is dropped, keeping the inner text. `Term`
+  // colors a glossary term's first mention; in prose it's just the word.
+  unwrapInline: ["Term"],
+
+  // The footnote component. A <TippyTooltip variant="footnote"
+  // content={<TippyTooltipContent>BODY</TippyTooltipContent>}>ANCHOR</TippyTooltip>
+  // becomes ANCHOR[^n] with BODY collected at the bottom. The self-closing form
+  // (no ANCHOR) attaches the marker to the preceding text.
+  footnote: {
+    component: "TippyTooltip",
+    variantAttr: "variant",
+    variantValue: "footnote",
+    contentComponent: "TippyTooltipContent",
+  },
+
+  // Non-footnote tooltips just collapse to their anchor text.
+  unwrapInlineTooltip: "TippyTooltip",
+
+  // Heading components → markdown headings.
+  headings: { H1: "#", H2: "##", H3: "###", H4: "####" },
+
+  // Block components removed entirely (CTAs, layout, subscribe forms).
+  dropBlock: ["PostArticleSubscribe", "PostArticleCTA"],
+
+  // Everything else that appears as a block-level capitalized JSX element is
+  // treated as a FIGURE → image placeholder. (After inline/heading/drop
+  // handling, the only block components left in a newt essay are the figures.)
+
+  // Plain HTML entities to normalize for a clean text doc.
+  entities: {
+    "&mdash;": "—",
+    "&ndash;": "–",
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&nbsp;": " ",
+    "&hellip;": "…",
+  },
+
+  // Map <sub>0-9</sub> to Unicode subscripts so plain text survives a paste.
+  subscriptDigits: true,
+
+  // A prop whose value names the figure (for the file slug), tried in order.
+  figureNameProps: ["beat", "variant", "id", "name", "kind"],
+};
+
+// Unicode subscript digits, for P<sub>50</sub> → P₅₀.
+export const SUBSCRIPTS = { 0: "₀", 1: "₁", 2: "₂", 3: "₃", 4: "₄", 5: "₅", 6: "₆", 7: "₇", 8: "₈", 9: "₉" };

--- a/scripts/article-export/shoot.mjs
+++ b/scripts/article-export/shoot.mjs
@@ -1,0 +1,70 @@
+// Capture every figure in an essay's manifest by driving a headless dev-server
+// page, then fold the rendered figcaptions back into the doc's alt text.
+
+import fs from "node:fs";
+import path from "node:path";
+import { launchChrome, Page, discoverFigures, captureFigure } from "./capture.mjs";
+
+export async function shootFigures({
+  route,
+  figures,
+  outDir,
+  baseUrl = "http://localhost:3000",
+  port = 9222,
+  pad = 28,
+  maxWidth = 1400,
+  log = () => {},
+}) {
+  const url = baseUrl.replace(/\/$/, "") + route;
+  const res = await fetch(url).catch(() => null);
+  if (!res || !res.ok) {
+    throw new Error(
+      `Dev server not reachable at ${url}. Start it first (e.g. \`npm run dev\`).`
+    );
+  }
+  fs.mkdirSync(outDir, { recursive: true });
+
+  log(`launching headless Chrome…`);
+  const { proc, port: p } = await launchChrome({ port });
+  let page;
+  try {
+    page = await Page.open(p, url);
+    const found = await discoverFigures(page);
+    if (found.length !== figures.length) {
+      log(`⚠ figure count mismatch — DOM has ${found.length}, manifest ${figures.length}. Capturing by index.`);
+    }
+    for (const fig of figures) {
+      const meta = found[fig.index];
+      const { buf, kind } = await captureFigure(page, fig.index, {
+        pad, maxWidth, frame: fig.frame,
+      });
+      fs.writeFileSync(path.join(outDir, fig.file), buf);
+      fig.caption = meta?.caption || null;
+      fig.kind = kind; // detected post-boot, so lazy 3D figures read correctly
+      fig.bytes = buf.length;
+      log(`  ✓ ${fig.file}  [${fig.kind}]  ${(buf.length / 1024).toFixed(0)} KB`);
+    }
+  } finally {
+    page?.close();
+    proc.kill();
+  }
+  return figures;
+}
+
+// Prefer an explicit override, else the rendered figcaption, else the
+// provisional alt the extractor guessed. Matches placeholders by filename.
+export function linkCaptions(markdown, figures, overrides = {}) {
+  const byFile = new Map(figures.map((f) => [f.file, f]));
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const m = /^> \*\*\[Image — `([^`]+)`\]\*\* /.exec(line);
+      if (!m) return line;
+      const fig = byFile.get(m[1]);
+      if (!fig) return line;
+      const ov = overrides.figures?.[m[1]] || {};
+      const alt = ov.alt || fig.caption || fig.alt;
+      return `> **[Image — \`${m[1]}\`]** ${alt}`;
+    })
+    .join("\n");
+}


### PR DESCRIPTION
## What

A reusable tool that turns a newt interactive essay into **marketing collateral**: a Substack-ready markdown doc + a folder of static figure screenshots — for newsletters, cross-posts, and places that can't run the live interactives.

```bash
npm run dev                                          # dev server up
node scripts/article-export/cli.mjs all hemoglobin   # → docs/<slug>/export/
```

Output: `essay.md` (footnotes pulled to the bottom, every figure → labelled image placeholder, prose verbatim), `figures/` (retina PNGs, ≤1400px, 28px margin), and a `figures.json` manifest.

## How it's structured

- **`extract.mjs`** — MDX → markdown (no browser). `TippyTooltip`→footnotes, `Term` stripped, `<H2>`→`##`, entities/subscripts normalized, subscribe/CTA dropped, each block-level figure → placeholder.
- **`capture.mjs`** — reusable headless-Chrome core: launch flags + `regionshot` + `<figure>` discovery.
- **`shoot.mjs`** — screenshots every `<figure>` in order; auto-handles 3D (Mol*/R3F), morph **players** (canvas + controls, frame 0), and 2D charts (default state).
- **`rules.mjs`** — the one place that knows the newt component vocabulary.
- **`cli.mjs`** — `extract` / `shoot` / `link` / `all`.
- **`README.md`** — usage, per-essay overrides, and the headless-WebGL writeup.

The linchpin: every interactive renders as a `<figure>`, mapping 1:1 to the MDX components in document order — so prose placeholders and screenshots line up with no per-figure wiring.

## The headless-WebGL gotcha (documented in capture.mjs)

Headless Chrome drops GPU-composited canvas layers from normal screenshots. Fix: launch with SwiftShader (`--use-gl=angle --use-angle=swiftshader`) + `--disable-gpu-compositing`, capture with `captureBeyondViewport`. Then Mol*/R3F figures composite into a plain screenshot. Mol* renders at 1×, so capture nudges the canvas to 2× for retina.

## Per-essay overrides

Optional `pages/essays/<slug>/export.config.json` keyed by generated filename: `alt` (better text for figures without a figcaption) and `frame` (morph player slider position).

## Notes

- Tested end-to-end on the hemoglobin essay (17 figures). Rules are tuned to newt; another essay using a component not in `rules.mjs`, or a figure that renders 0/2 `<figure>`s, may need a small rule tweak — `rules.mjs` is the extension point.
- Tools only — no generated docs/images committed.

## Requirements

Node ≥ 21 (built-in `WebSocket`), Google Chrome (`CHROME_BIN` to override), `sharp` (already a dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)