### PR TITLE
Add figure GIF recorder to article-export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# article-export output (generated docs, screenshots, GIFs)
+docs/*/export/

--- a/pages/essays/hemoglobin/recordings.json
+++ b/pages/essays/hemoglobin/recordings.json
@@ -1,0 +1,15 @@
+{
+  "defaults": { "fps": 20, "maxWidth": 800 },
+  "recordings": [
+    { "name": "oxygen-binding", "figure": "movement are not drawn" },
+    { "name": "binding-distal-histidine", "figure": "and the oxygen, are not drawn" },
+    { "name": "tense-relaxed-switch", "figure": "subunits sit apart" },
+    { "name": "bpg-doorstop", "figure": "2,3-BPG wedged" },
+    { "name": "proton-binding", "figure": "incoming proton" },
+    {
+      "name": "lungs-to-muscle",
+      "figure": 14,
+      "sweep": ["lungs", "resting tissue", "working muscle"]
+    }
+  ]
+}

--- a/scripts/article-export/README.md
+++ b/scripts/article-export/README.md
@@ -49,9 +49,102 @@ line up automatically, no per-figure wiring.
 | `extract <slug>` | no | MDX → `essay.md` + `figures.json` |
 | `shoot <slug>`   | yes | screenshot figures from an existing manifest |
 | `all <slug>`     | yes | extract → shoot → link (the usual one) |
+| `record <slug>`  | yes (+ ffmpeg) | record one animated figure as a looping **GIF** |
 
-Flags: `--out <dir>`, `--base-url <url>` (default `http://localhost:3000`),
-`--pad <px>` (default 28), `--max-width <px>` (default 1400), `--port <n>`.
+Flags (extract/shoot/all): `--out <dir>`, `--base-url <url>` (default
+`http://localhost:3000`), `--pad <px>` (default 28), `--max-width <px>` (default
+1400), `--port <n>`.
+
+## Recording a figure as a GIF
+
+`record` is the moving sibling of `shoot`. It captures the **same region** as the
+screenshot — the figure's visual plus its controls, so the GIF has the same
+framing and aspect ratio as the still — but instead of one frame it captures the
+whole animation and stitches the poses into a looping GIF with ffmpeg
+(`palettegen`/`paletteuse`, far cleaner than a naive palette).
+
+```bash
+# a Mol* morph player (scrub mode)
+node scripts/article-export/cli.mjs record hemoglobin \
+  --name oxygen-binding --figure "movement are not drawn"
+
+# a 2D toggle figure (tween mode)
+node scripts/article-export/cli.mjs record hemoglobin \
+  --name tense-relaxed-switch --figure "subunits sit apart"
+
+# a slider chart, walked through named checkpoints (sweep mode)
+node scripts/article-export/cli.mjs record hemoglobin --figure 14 \
+  --name lungs-to-muscle --sweep "lungs,resting tissue,working muscle"
+```
+
+All three strategies are deterministic — a headless screenshot takes far longer
+than an animation frame, so capturing real-time playback would sample unevenly
+and tear. `record` picks the mode from the figure (or `--sweep`):
+
+- **scrub** — morph players (Mol*) expose a frame slider. It drives the slider
+  one frame at a time, waiting for the engine to settle between captures. The
+  play button's glyph is forced per frame so the loop reads like a real
+  recording — **play** on the opening hold, **pause** through the morph,
+  **replay** on the closing hold (disable with `--no-play-icon`).
+- **tween** — toggle figures (the 2D T↔R switch, the 2,3-BPG doorstop) animate a
+  `requestAnimationFrame` + `performance.now` tween on a button click. It
+  installs a **virtual clock** (queues rAF, freezes `performance.now`), clicks
+  the toggle, then advances the clock in even steps and snapshots each — no
+  per-figure pose maths, just *advance time, let React render, capture*. Captured
+  as a T→R→T round trip so the loop is seamless.
+- **sweep** (`--sweep`) — a slider chart walked through a list of checkpoints,
+  sweeping smoothly between them and pausing at each. A checkpoint is a raw
+  slider value or a **preset-button label** (clicked to read where the slider
+  lands), so the journey reads in the figure's own words —
+  `--sweep "lungs,resting tissue,working muscle"` drives pO₂ 95 → 40 → 20, the
+  curve marker descending and the O₂ seats emptying as a red cell unloads from
+  lungs to tissue. Loops back to the first checkpoint for a seamless cycle
+  (`--no-loop-back` to stop after the last).
+
+`--figure` picks the figure: a document-order index, a figcaption substring
+(both resolve without mounting), or `first-player` (the default — scans for the
+first canvas+slider figure, mounting lazy figures as it goes; pass an explicit
+index/caption to skip the scan when several lazy 3D figures precede the target).
+
+Record flags: `--out <file>` or `--name <basename>`, `--figure <sel>`,
+`--fps <n>` (default 20 — in tween mode the GIF plays the transition at real
+speed), `--frames <n>` (scrub: default every baked frame),
+`--max-width <px>` (default 800), `--pad <px>` (default 28),
+`--settle <ms>` (per-step wait; default 500 scrub / 80 tween / 40 sweep),
+`--start-hold <ms>` / `--end-hold <ms>` (default 600 / 900 — the opening and the
+middle/R hold), `--no-play-icon`. Sweep mode: `--sweep <list>`,
+`--checkpoint-hold <ms>` (default 1000), `--sweep-rate <units/sec>` (default 45),
+`--no-loop-back`. Plus `--keep-frames`, `--port <n>` (default 9223). Needs
+`ffmpeg` on `PATH` (or `FFMPEG_BIN`).
+
+### A recordings manifest (the usual way)
+
+Rather than remember a command per figure, list an essay's GIFs in
+`pages/essays/<slug>/recordings.json` and produce them all at once:
+
+```bash
+node scripts/article-export/cli.mjs record hemoglobin        # every recording
+node scripts/article-export/cli.mjs record hemoglobin --only bpg-doorstop
+```
+
+```json
+{
+  "defaults": { "fps": 20, "maxWidth": 800 },
+  "recordings": [
+    { "name": "oxygen-binding", "figure": "movement are not drawn" },
+    { "name": "tense-relaxed-switch", "figure": "subunits sit apart" },
+    { "name": "lungs-to-muscle", "figure": 14,
+      "sweep": ["lungs", "resting tissue", "working muscle"] }
+  ]
+}
+```
+
+Each entry is a recording **spec** — `name` (the output basename) plus any
+`recordFigure` option (`figure`, `sweep`, `fps`, `maxWidth`, `checkpointHoldMs`,
+…); `defaults` apply to every entry, an entry overrides them. The mode is still
+auto-detected per figure, so one manifest mixes morphs, toggles and charts.
+`record <slug>` with `--figure`/`--name`/`--sweep` records that one figure
+ad-hoc instead; with none, it runs the manifest.
 
 ## Per-essay overrides
 

--- a/scripts/article-export/capture.mjs
+++ b/scripts/article-export/capture.mjs
@@ -163,7 +163,7 @@ export class Page {
 // A small in-page helper, shared by discovery and capture, that decides when a
 // figure has finished rendering: any WebGL canvas has drawn content, and any
 // player control (a disabled-until-ready slider) has become enabled.
-const READINESS_HELPERS = `
+export const READINESS_HELPERS = `
   const sleep = (ms) => new Promise(r => setTimeout(r, ms));
   const hasContent = (c) => {
     try {
@@ -196,16 +196,14 @@ export async function discoverFigures(page) {
   })()`);
 }
 
-// Capture one figure (by document-order index) as a padded, width-capped PNG.
-// Works for 3D (canvas + gizmo), morph players (canvas + controls), and 2D
-// (SVG/charts). `frame` (a number) drives a morph slider; omit to keep the
-// figure's default interactive state. The capture region is the figure's first
-// child div — the visual content, excluding any sibling <figcaption>.
-export async function captureFigure(
-  page,
-  index,
-  { pad = 28, maxWidth = 1400, frame = null, waitMs = 12000 } = {}
-) {
+// Bring a figure to a capturable resting state and return its capture region.
+// Scrolls it into view, waits until it's ready (canvas drawn, slider enabled),
+// nudges any WebGL canvas to ~2x for retina, hides Mol* toasts, then returns the
+// figure's first child div rect (the visual content, excluding any sibling
+// <figcaption>) in page coordinates plus the detected canvas/range flags. The
+// rect is stable across frame changes, so a recorder can prepare once and reuse
+// it for every frame. No frame is set here — that's setFigureFrame's job.
+export async function prepareFigure(page, index, { waitMs = 12000 } = {}) {
   const info = await page.eval(`(async () => {
     ${READINESS_HELPERS}
     const figs = [...document.querySelectorAll("figure")];
@@ -235,17 +233,6 @@ export async function captureFigure(
       }
       await sleep(900);
     }
-    // Optional: drive a morph slider to a frame; otherwise keep default state.
-    const frame = ${frame === null ? "null" : Number(frame)};
-    const sld = el.querySelector('input[type="range"]');
-    if (frame !== null && sld && !sld.disabled) {
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype, "value").set;
-      setter.call(sld, String(frame));
-      sld.dispatchEvent(new Event("input", { bubbles: true }));
-      sld.dispatchEvent(new Event("change", { bubbles: true }));
-      await sleep(900);
-    }
     el.querySelectorAll('[class*="msp-toast"]').forEach((e) => { e.style.display = "none"; });
     await sleep(500);
     const r = el.getBoundingClientRect();
@@ -258,19 +245,85 @@ export async function captureFigure(
     });
   })()`);
   const rect = JSON.parse(info);
-  if (rect.error) throw new Error(`captureFigure[${index}]: ${rect.error}`);
+  if (rect.error) throw new Error(`prepareFigure[${index}]: ${rect.error}`);
+  return rect;
+}
 
-  let buf = await page.captureClip(rect);
+const PLAY_ICON_PATHS = {
+  play: "M8 5v14l11-7z",
+  pause: "M6 5h4v14H6zM14 5h4v14h-4z",
+  restart: "M12 5V2L7 7l5 5V8a6 6 0 1 1-6 6H4a8 8 0 1 0 8-9z",
+};
+
+// Drive a morph player's slider to `frame` (0-based) and let Mol* settle.
+// React owns the slider (onChange fires on "input"), so we poke the native value
+// setter and dispatch input/change exactly as a user drag would. `settle` is how
+// long to wait for the engine to recommit + repaint before the caller captures.
+// `icon` optionally overwrites the play button's glyph for this one capture
+// (e.g. force "pause" mid-playthrough so a recording looks like a real play) —
+// applied after the settle, since the scrub's React re-render resets it first.
+export async function setFigureFrame(
+  page,
+  index,
+  frame,
+  { settle = 500, icon = null } = {}
+) {
+  await page.eval(`(async () => {
+    const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+    const figs = [...document.querySelectorAll("figure")];
+    const el = figs[${index}] && figs[${index}].querySelector(":scope > div");
+    if (!el) return;
+    const sld = el.querySelector('input[type="range"]');
+    if (sld && !sld.disabled) {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype, "value").set;
+      setter.call(sld, String(${Number(frame)}));
+      sld.dispatchEvent(new Event("input", { bubbles: true }));
+      sld.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+    await sleep(${Number(settle)});
+    const icon = ${icon ? JSON.stringify(PLAY_ICON_PATHS[icon] || null) : "null"};
+    if (icon) {
+      const path = el.querySelector('button svg path');
+      if (path) { path.setAttribute('d', icon); await sleep(30); }
+    }
+  })()`);
+}
+
+// Shared post-processing for a raw clip buffer: a white margin (so figures
+// breathe against newsletter prose) then a width cap. Applied identically to
+// stills and to every GIF frame, so a recording frames its subject exactly like
+// the screenshot would.
+export async function padAndResize(buf, { pad = 28, maxWidth = 1400 } = {}) {
   const sharp = (await import("sharp")).default;
   const p = pad * VIEW.dsf; // capture is at dsf, so pad in device px
   buf = await sharp(buf)
     .extend({ top: p, bottom: p, left: p, right: p, background: "#ffffff" })
     .png()
     .toBuffer();
-  let w = buf.readUInt32BE(16);
+  const w = buf.readUInt32BE(16);
   if (maxWidth && w > maxWidth) {
     buf = await sharp(buf).resize({ width: maxWidth }).png().toBuffer();
   }
+  return buf;
+}
+
+// Capture one figure (by document-order index) as a padded, width-capped PNG.
+// Works for 3D (canvas + gizmo), morph players (canvas + controls), and 2D
+// (SVG/charts). `frame` (a number) drives a morph slider; omit to keep the
+// figure's default interactive state. The capture region is the figure's first
+// child div — the visual content, excluding any sibling <figcaption>.
+export async function captureFigure(
+  page,
+  index,
+  { pad = 28, maxWidth = 1400, frame = null, waitMs = 12000 } = {}
+) {
+  const rect = await prepareFigure(page, index, { waitMs });
+  // Optional: drive a morph slider to a frame; otherwise keep default state.
+  if (frame !== null && rect.hasRange) {
+    await setFigureFrame(page, index, frame, { settle: 900 });
+  }
+  const buf = await padAndResize(await page.captureClip(rect), { pad, maxWidth });
   const kind = rect.hasCanvas ? (rect.hasRange ? "player" : "3d") : "2d";
   return { buf, kind };
 }

--- a/scripts/article-export/cli.mjs
+++ b/scripts/article-export/cli.mjs
@@ -9,23 +9,55 @@
 //   shoot    screenshot every figure listed in the manifest (needs dev server)
 //   all      extract, shoot, then link captions into the doc (the usual one)
 //   link     re-apply captions/overrides to the doc from the manifest (no browser)
+//   record   record figures as looping GIFs — one ad-hoc, or a whole essay's
+//            recordings.json manifest (needs dev server + ffmpeg)
 //
-// Flags:
+// Flags (extract/shoot/all):
 //   --out <dir>        output dir (default docs/<slug>/export)
 //   --base-url <url>   dev server (default http://localhost:3000)
 //   --pad <px>         white margin around each figure (default 28)
 //   --max-width <px>   downscale cap (default 1400)
 //   --port <n>         Chrome debug port (default 9222)
+//
+// Flags (record):
+//   (no target)        batch: produce every entry in pages/essays/<slug>/recordings.json
+//   --only <name>      batch: produce just the manifest entry with this name
+//   --out <file>       output GIF path (default docs/<slug>/export/figures/<name>.gif)
+//   --name <basename>  basename for the default --out path (default "recording")
+//   --figure <sel>     which figure: index, "first-player" (default), or caption substring
+//   --fps <n>          GIF frame rate (default 20)
+//   --frames <n>       scrub mode: sample N frames across the morph (default all)
+//   --max-width <px>   downscale cap (default 800)
+//   --pad <px>         white margin (default 28, matches the screenshot)
+//   --settle <ms>      per-step wait (default 500 scrub / 80 tween)
+//   --start-hold <ms>  freeze on the opening pose (default 600)
+//   --end-hold <ms>    freeze on the closing/R pose (default 900)
+//   --no-play-icon     scrub mode: don't force the play/pause/replay glyph
+//   --sweep <list>     slider chart: comma-separated checkpoints (values or preset
+//                      labels, e.g. "lungs,resting tissue,working muscle")
+//   --checkpoint-hold <ms>  pause at each sweep checkpoint (default 1000)
+//   --sweep-rate <n>   slider units/sec between checkpoints (default 45)
+//   --no-loop-back     sweep mode: don't sweep back to the first checkpoint
+//   --keep-frames      keep the intermediate PNG frames next to the GIF
+//   --base-url <url>   dev server (default http://localhost:3000)
+//   --port <n>         Chrome debug port (default 9223)
 
 import fs from "node:fs";
 import path from "node:path";
 import { extractEssay, loadOverrides } from "./extract.mjs";
 import { shootFigures, linkCaptions } from "./shoot.mjs";
+import { recordFigure } from "./record.mjs";
+import { RULES } from "./rules.mjs";
 
 function parseFlags(args) {
   const o = {};
   for (let i = 0; i < args.length; i++) {
-    if (args[i].startsWith("--")) o[args[i].slice(2)] = args[i + 1], i++;
+    if (!args[i].startsWith("--")) continue;
+    const key = args[i].slice(2);
+    const next = args[i + 1];
+    // A flag with no value (end of args or followed by another flag) is boolean.
+    if (next === undefined || next.startsWith("--")) o[key] = true;
+    else (o[key] = next), i++;
   }
   return o;
 }
@@ -33,7 +65,9 @@ function parseFlags(args) {
 const [cmd, slug, ...rest] = process.argv.slice(2);
 if (!cmd || !slug || cmd === "--help") {
   console.log(
-    "usage: node scripts/article-export/cli.mjs <extract|shoot|all> <essay-slug> [--out dir] [--base-url url] [--pad px] [--max-width px]"
+    "usage: node scripts/article-export/cli.mjs <extract|shoot|all|record> <essay-slug> [flags]\n" +
+      "  record (batch):  record <slug>            # all of pages/essays/<slug>/recordings.json\n" +
+      "  record (one):    record <slug> --figure <sel> --name <basename> [--sweep ...]"
   );
   process.exit(cmd ? 0 : 1);
 }
@@ -89,6 +123,78 @@ async function main() {
       fs.writeFileSync(docPath, linked);
     }
     console.log(`\nshot ${shot.length} figures → ${path.relative(root, figuresDir)}/`);
+    return;
+  }
+
+  if (cmd === "record") {
+    const route = flags.route || RULES.routeFor(slug);
+    // Settings shared by every recording in this run; per-recording specs layer
+    // on top. base-url/port apply to both single and batch.
+    const common = {
+      route,
+      baseUrl: flags["base-url"] || "http://localhost:3000",
+      port: Number(flags.port || 9223),
+      keepFrames: !!flags["keep-frames"],
+      log: (m) => console.log(m),
+    };
+    // A "spec" uses recordFigure's own option names (figure, sweep, fps, …) plus
+    // name/out; config entries are specs verbatim, and CLI flags map to one.
+    const runRecording = (spec) => {
+      const outFile = spec.out
+        ? path.resolve(spec.out)
+        : path.join(figuresDir, `${spec.name || "recording"}.gif`);
+      return recordFigure({ ...common, ...spec, outFile });
+    };
+
+    // Single ad-hoc recording when a target is named on the CLI.
+    if (flags.figure || flags.name || flags.sweep || flags.out) {
+      const result = await runRecording({
+        name: flags.name,
+        out: flags.out,
+        figure: flags.figure || "first-player",
+        frames: flags.frames ? Number(flags.frames) : null,
+        fps: flags.fps ? Number(flags.fps) : undefined,
+        startHoldMs: flags["start-hold"] != null ? Number(flags["start-hold"]) : undefined,
+        endHoldMs: flags["end-hold"] != null ? Number(flags["end-hold"]) : undefined,
+        pad: flags.pad ? Number(flags.pad) : undefined,
+        maxWidth: flags["max-width"] ? Number(flags["max-width"]) : undefined,
+        settle: flags.settle != null ? Number(flags.settle) : null,
+        playIcon: !flags["no-play-icon"],
+        sweep: flags.sweep
+          ? String(flags.sweep).split(",").map((s) => s.trim()).filter(Boolean)
+          : null,
+        checkpointHoldMs: flags["checkpoint-hold"] != null ? Number(flags["checkpoint-hold"]) : undefined,
+        sweepRate: flags["sweep-rate"] != null ? Number(flags["sweep-rate"]) : undefined,
+        loopBack: !flags["no-loop-back"],
+      });
+      console.log(`\ndone → ${path.relative(root, result.outFile)}  (${result.frames} frames)`);
+      return;
+    }
+
+    // Otherwise: batch — produce every recording in the essay's manifest.
+    const cfgPath = path.join(root, "pages/essays", slug, "recordings.json");
+    if (!fs.existsSync(cfgPath)) {
+      console.error(
+        `No target given and no manifest at ${path.relative(root, cfgPath)}.\n` +
+          `Record one figure with --figure/--name/--sweep, or add a recordings.json.`
+      );
+      process.exit(1);
+    }
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+    let entries = cfg.recordings || [];
+    if (flags.only) entries = entries.filter((e) => e.name === flags.only);
+    if (!entries.length) {
+      console.error(
+        flags.only ? `No recording named "${flags.only}" in the manifest.` : `Manifest has no recordings.`
+      );
+      process.exit(1);
+    }
+    console.log(`recording ${entries.length} figure(s) from ${path.relative(root, cfgPath)}…`);
+    for (const e of entries) {
+      console.log(`\n▶ ${e.name}`);
+      await runRecording({ ...(cfg.defaults || {}), ...e });
+    }
+    console.log(`\ndone → ${entries.length} GIF(s) → ${path.relative(root, figuresDir)}/`);
     return;
   }
 

--- a/scripts/article-export/record.mjs
+++ b/scripts/article-export/record.mjs
@@ -1,0 +1,424 @@
+// Record an interactive figure as a looping GIF — the moving sibling of
+// shoot.mjs's still screenshots. Same headless dev-server page, same capture
+// region (so the GIF frames its subject exactly like the screenshot, controls
+// included), but instead of one frame it captures the whole animation and
+// stitches the sequence into a GIF with ffmpeg.
+//
+// Two figure shapes, two capture strategies — both deterministic, because a
+// headless screenshot takes far longer than an animation frame, so capturing
+// real-time playback would sample unevenly and tear:
+//   • scrub — morph players (Mol*) expose a frame slider; we drive it one frame
+//     at a time and wait for the engine to settle between captures.
+//   • tween — toggle figures (the 2D T↔R switch, the 2,3-BPG doorstop) animate a
+//     rAF + performance.now tween on a button click; we install a *virtual
+//     clock* (queue rAF, freeze performance.now), click the toggle, then advance
+//     the clock in even steps and snapshot each — no per-figure pose maths, just
+//     "advance time, let React render, capture." Captured as a T→R→T round trip
+//     so the loop is seamless.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import {
+  launchChrome,
+  Page,
+  discoverFigures,
+  prepareFigure,
+  setFigureFrame,
+  padAndResize,
+} from "./capture.mjs";
+
+const FFMPEG = process.env.FFMPEG_BIN || "ffmpeg";
+
+// Resolve a `--figure` selector against the discovered figures. Accepts a
+// numeric document-order index, a substring matched case-insensitively against
+// the figcaption (both work pre-mount — captions render even while a lazy 3D
+// figure is still a placeholder), or "first-player" (default).
+//
+// "first-player" is the only mode that must mount: morph players are lazy, so a
+// figure that shows no canvas/slider at load may become a player once scrolled
+// near. We scan in document order, scrolling each candidate into view until one
+// exposes both a canvas and a slider. Pass an explicit index/caption to skip the
+// scan when an essay has several lazy 3D figures before the target.
+async function resolveFigure(page, found, selector) {
+  if (/^\d+$/.test(String(selector))) {
+    const m = found[Number(selector)];
+    if (!m) throw new Error(`no figure at index ${selector} (page has ${found.length})`);
+    return m;
+  }
+  if (selector && selector !== "first-player") {
+    const needle = String(selector).toLowerCase();
+    const m = found.find((f) => (f.caption || "").toLowerCase().includes(needle));
+    if (!m) throw new Error(`no figure caption matching "${selector}"`);
+    return m;
+  }
+  const already = found.find((f) => f.hasCanvas && f.hasRange);
+  if (already) return already;
+  for (const f of found) {
+    const isPlayer = await page.eval(`(async () => {
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+      const fig = document.querySelectorAll("figure")[${f.index}];
+      if (!fig) return false;
+      const el = fig.querySelector(":scope > div") || fig;
+      el.scrollIntoView({ block: "center" });
+      for (let i = 0; i < 16; i++) {
+        if (el.querySelector("canvas") && el.querySelector('input[type="range"]')) return true;
+        await sleep(250);
+      }
+      return false;
+    })()`);
+    if (isPlayer) return { ...f, hasCanvas: true, hasRange: true };
+  }
+  throw new Error("no morph player (canvas + slider) found on the page");
+}
+
+// Evenly pick `count` frame indices spanning 0…max (inclusive at both ends).
+// Omitting `count` (or asking for >= the baked frames) keeps every frame.
+function sampleFrames(max, count) {
+  if (!count || count >= max + 1) return Array.from({ length: max + 1 }, (_, i) => i);
+  return Array.from({ length: count }, (_, i) => Math.round((i * max) / (count - 1)));
+}
+
+// Stitch a sequence of equal-size PNG frame files into a looping GIF. Two passes
+// via ffmpeg: palettegen builds an optimal 256-colour palette for the clip, then
+// paletteuse renders against it with error-diffusion dither — far cleaner on a
+// WebGL render than a naive global palette.
+function encodeGif({ pattern, fps, outFile, log }) {
+  const args = [
+    "-y",
+    "-framerate", String(fps),
+    "-i", pattern,
+    "-vf", "split[s0][s1];[s0]palettegen=stats_mode=full[p];[s1][p]paletteuse=dither=sierra2_4a",
+    "-loop", "0",
+    outFile,
+  ];
+  return new Promise((resolve, reject) => {
+    const proc = spawn(FFMPEG, args, { stdio: ["ignore", "ignore", "pipe"] });
+    let err = "";
+    proc.stderr.on("data", (d) => (err += d));
+    proc.on("error", (e) =>
+      reject(
+        e.code === "ENOENT"
+          ? new Error(`ffmpeg not found (set FFMPEG_BIN or \`brew install ffmpeg\`).`)
+          : e
+      )
+    );
+    proc.on("close", (code) =>
+      code === 0 ? resolve() : reject(new Error(`ffmpeg exited ${code}:\n${err.slice(-800)}`))
+    );
+  });
+}
+
+// Build a frame timeline by scrubbing a morph player's slider 0…max. The play
+// button's glyph is forced per frame so the loop reads like a real recording:
+// "play" on the opening hold, "pause" through the morph, "replay" on the close.
+async function collectScrubFrames(
+  page,
+  index,
+  rect,
+  { frames, fps, startHoldMs, endHoldMs, pad, maxWidth, settle, playIcon, log }
+) {
+  // Don't capture frame 0 until the player is truly ready (slider enabled = Mol*
+  // booted, the "Loading 3D…" overlay gone), or the opening hold freezes on the
+  // loading state instead of the molecule.
+  const ready = await page.eval(`(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const el = document.querySelectorAll("figure")[${index}].querySelector(":scope > div");
+    const t0 = Date.now();
+    while (Date.now() - t0 < 30000) {
+      const sld = el.querySelector('input[type="range"]');
+      if (sld && !sld.disabled) { await sleep(700); return true; }
+      await sleep(250);
+    }
+    return false;
+  })()`);
+  if (!ready) log(`  ⚠ player still loading after 30s — frame 0 may be incomplete`);
+
+  const max = Number(
+    await page.eval(
+      `String(document.querySelectorAll("figure")[${index}].querySelector('input[type=range]').max)`
+    )
+  );
+  const seq = sampleFrames(max, frames);
+  log(`  scrub player — ${seq.length} frames (slider 0…${max}) at ${maxWidth}px…`);
+
+  const buffers = [];
+  for (let i = 0; i < seq.length; i++) {
+    const icon = !playIcon ? null : i === 0 ? "play" : i === seq.length - 1 ? "restart" : "pause";
+    await setFigureFrame(page, index, seq[i], { settle, icon });
+    buffers.push(await padAndResize(await page.captureClip(rect), { pad, maxWidth }));
+    if ((i + 1) % 5 === 0 || i === seq.length - 1) log(`    …${i + 1}/${seq.length}`);
+  }
+
+  const holdStart = Math.max(0, Math.round((startHoldMs / 1000) * fps));
+  const holdEnd = Math.max(0, Math.round((endHoldMs / 1000) * fps));
+  const timeline = [
+    ...Array(holdStart).fill(buffers[0]),
+    ...buffers,
+    ...Array(holdEnd).fill(buffers[buffers.length - 1]),
+  ];
+  return { timeline, frameCount: buffers.length };
+}
+
+// Build a frame timeline for a toggle figure by driving its rAF tween with a
+// virtual clock. Captures a T→R→T round trip: hold T, play to R, hold R, play
+// back to T — so looping the GIF (T at the end → T at the start) is seamless.
+async function collectTweenFrames(
+  page,
+  index,
+  rect,
+  { fps, startHoldMs, midHoldMs, pad, maxWidth, settle, log }
+) {
+  const dt = Math.max(1, Math.round(1000 / fps)); // virtual ms advanced per frame
+  const capture = async () => padAndResize(await page.captureClip(rect), { pad, maxWidth });
+
+  const btnCount = await page.eval(
+    `document.querySelectorAll("figure")[${index}].querySelectorAll('button').length`
+  );
+  if (btnCount < 2) {
+    throw new Error(
+      `figure ${index} has no slider and < 2 toggle buttons — nothing to animate`
+    );
+  }
+  log(`  toggle figure — driving the tween with a virtual clock at ${maxWidth}px…`);
+
+  // Queue every rAF callback instead of running it, and freeze performance.now to
+  // a virtual time we control — so the tween advances only when we flush.
+  await page.eval(`(() => {
+    if (window.__vclock) return;
+    window.__vclock = true; window.__vt = 0; window.__rafMap = new Map(); let id = 1;
+    window.__realRAF = window.requestAnimationFrame.bind(window);
+    window.__realCAF = window.cancelAnimationFrame.bind(window);
+    window.__realNow = performance.now.bind(performance);
+    window.requestAnimationFrame = (cb) => { const i = id++; window.__rafMap.set(i, cb); return i; };
+    window.cancelAnimationFrame = (i) => { window.__rafMap && window.__rafMap.delete(i); };
+    performance.now = () => window.__vt;
+  })()`);
+
+  // Click a toggle button, then advance the virtual clock in even steps —
+  // flushing the queued rAF tick each time — until the tween stops rescheduling
+  // (its last frame reached). Capturing after each step gives evenly-spaced poses.
+  const playToggle = async (btnIndex) => {
+    const out = [];
+    await page.eval(`(async () => {
+      const b = document.querySelectorAll("figure")[${index}].querySelectorAll('button');
+      if (b[${btnIndex}]) b[${btnIndex}].click();
+      await new Promise((r) => setTimeout(r, 90));
+    })()`);
+    for (let step = 0; step < 400; step++) {
+      const pending = await page.eval(`(async () => {
+        window.__vt += ${dt};
+        const cbs = [...window.__rafMap.values()];
+        window.__rafMap.clear();
+        cbs.forEach((cb) => { try { cb(window.__vt); } catch (e) {} });
+        await new Promise((r) => setTimeout(r, ${settle}));
+        return window.__rafMap.size;
+      })()`);
+      out.push(await capture());
+      if (pending === 0) break; // tween finished — no further frame scheduled
+    }
+    return out;
+  };
+
+  const open = await capture(); // starting (left/T) pose
+  const fwd = await playToggle(1); // → right (R)
+  const rev = await playToggle(0); // → left (T)
+
+  // Restore the real clock so the page behaves normally afterwards.
+  await page.eval(`(() => {
+    if (!window.__vclock) return;
+    window.requestAnimationFrame = window.__realRAF;
+    window.cancelAnimationFrame = window.__realCAF;
+    performance.now = window.__realNow;
+    delete window.__vclock; delete window.__rafMap; delete window.__vt;
+  })()`);
+
+  const holdStart = Math.max(0, Math.round((startHoldMs / 1000) * fps));
+  const holdMid = Math.max(0, Math.round((midHoldMs / 1000) * fps));
+  const rPose = fwd.length ? fwd[fwd.length - 1] : open;
+  const timeline = [
+    ...Array(holdStart).fill(open),
+    ...fwd,
+    ...Array(holdMid).fill(rPose),
+    ...rev,
+  ];
+  log(`  ${fwd.length} + ${rev.length} transition frames captured`);
+  return { timeline, frameCount: fwd.length + rev.length };
+}
+
+// Turn each checkpoint token into a slider value. A bare number is used as-is; a
+// label (e.g. "lungs") is matched against the figure's preset buttons — we click
+// the match and read where the slider lands, so the journey is described in the
+// figure's own vocabulary instead of magic numbers.
+async function resolveCheckpoints(page, index, tokens) {
+  const out = [];
+  for (const tok of tokens) {
+    const t = String(tok).trim();
+    if (/^-?\d+(\.\d+)?$/.test(t)) { out.push(Number(t)); continue; }
+    const v = await page.eval(`(async () => {
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+      const fig = document.querySelectorAll("figure")[${index}];
+      const el = fig && (fig.querySelector(":scope > div") || fig);
+      if (!el) return null;
+      const needle = ${JSON.stringify(t.toLowerCase())};
+      const btn = [...el.querySelectorAll('button')].find((b) => (b.textContent || "").toLowerCase().includes(needle));
+      if (!btn) return null;
+      btn.click();
+      await sleep(60);
+      const s = el.querySelector('input[type="range"]');
+      return s ? Number(s.value) : null;
+    })()`);
+    if (v == null) throw new Error(`checkpoint "${t}" not found (no preset button matching it)`);
+    out.push(v);
+  }
+  return out;
+}
+
+// Build a frame timeline that walks a continuous slider through a sequence of
+// checkpoints — sweeping smoothly between them and holding at each — then
+// (loopBack) sweeps back to the first so the GIF loops seamlessly. For the
+// saturation chart: lungs → resting tissue → working muscle, the O₂ unloading a
+// red cell does as it travels from the lungs out to the tissues.
+async function collectSweepFrames(
+  page,
+  index,
+  rect,
+  { checkpoints, fps, checkpointHoldMs, sweepRate, pad, maxWidth, settle, loopBack, log }
+) {
+  const cps = await resolveCheckpoints(page, index, checkpoints);
+  const meta =
+    (await page.eval(`(() => {
+      const el = document.querySelectorAll("figure")[${index}].querySelector(":scope > div");
+      const s = el && el.querySelector('input[type="range"]');
+      return s ? { min: Number(s.min) || 0, max: Number(s.max) || 100, step: Number(s.step) || 1 } : null;
+    })()`)) || { min: 0, max: 100, step: 1 };
+  log(`  sweep — ${cps.join(" → ")} (slider ${meta.min}…${meta.max}) at ${maxWidth}px…`);
+
+  const capture = async () => padAndResize(await page.captureClip(rect), { pad, maxWidth });
+  const snap = (v) =>
+    Math.max(meta.min, Math.min(meta.max, Math.round(v / meta.step) * meta.step));
+  // Frames between two checkpoints, at a constant slider speed (sweepRate units
+  // per second). Excludes the start (already captured), includes the endpoint.
+  const unitsPerFrame = Math.max(meta.step, sweepRate / fps);
+  const segment = (a, b) => {
+    const n = Math.max(1, Math.round(Math.abs(b - a) / unitsPerFrame));
+    return Array.from({ length: n }, (_, k) => snap(a + ((b - a) * (k + 1)) / n));
+  };
+  const hold = Math.max(1, Math.round((checkpointHoldMs / 1000) * fps));
+
+  const buffers = [];
+  await setFigureFrame(page, index, snap(cps[0]), { settle });
+  const first = await capture();
+  for (let i = 0; i < hold; i++) buffers.push(first); // hold the opening checkpoint
+
+  for (let i = 0; i < cps.length - 1; i++) {
+    for (const v of segment(cps[i], cps[i + 1])) {
+      await setFigureFrame(page, index, v, { settle });
+      buffers.push(await capture());
+    }
+    const landed = buffers[buffers.length - 1];
+    for (let h = 1; h < hold; h++) buffers.push(landed); // pause at this checkpoint
+    log(`    …checkpoint ${i + 2}/${cps.length} (slider ${cps[i + 1]})`);
+  }
+
+  if (loopBack && cps.length > 1) {
+    const back = segment(cps[cps.length - 1], cps[0]);
+    back.pop(); // the final frame == the opening checkpoint; the loop supplies it
+    for (const v of back) {
+      await setFigureFrame(page, index, v, { settle });
+      buffers.push(await capture());
+    }
+  }
+  return { timeline: buffers, frameCount: buffers.length };
+}
+
+export async function recordFigure({
+  route,
+  outFile,
+  baseUrl = "http://localhost:3000",
+  port = 9223,
+  figure = "first-player",
+  frames = null, // sample N frames across the morph; null = every baked frame
+  fps = 20,
+  startHoldMs = 600, // freeze on the opening pose (T / frame 0)
+  endHoldMs = 900, // freeze on the closing pose (R / last frame)
+  pad = 28,
+  maxWidth = 800,
+  settle = null, // ms to settle after each step (per-mode default if unset)
+  playIcon = true, // force the "pause" glyph mid-morph so it reads as playing
+  sweep = null, // checkpoint list (values/labels) → sweep mode on a slider chart
+  checkpointHoldMs = 1000, // pause at each sweep checkpoint
+  sweepRate = 45, // slider units per second between checkpoints
+  loopBack = true, // sweep back to the first checkpoint to close the loop
+  keepFrames = false,
+  log = () => {},
+}) {
+  const url = baseUrl.replace(/\/$/, "") + route;
+  const res = await fetch(url).catch(() => null);
+  if (!res || !res.ok) {
+    throw new Error(`Dev server not reachable at ${url}. Start it first (e.g. \`npm run dev\`).`);
+  }
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  const frameDir = keepFrames
+    ? path.join(path.dirname(outFile), path.basename(outFile, path.extname(outFile)) + ".frames")
+    : fs.mkdtempSync(path.join(os.tmpdir(), "newt-gif-"));
+  fs.mkdirSync(frameDir, { recursive: true });
+
+  log(`launching headless Chrome…`);
+  const { proc, port: p } = await launchChrome({ port });
+  let page;
+  try {
+    page = await Page.open(p, url);
+    const found = await discoverFigures(page);
+    const target = await resolveFigure(page, found, figure);
+    log(`figure #${target.index}${target.caption ? ` — "${target.caption}"` : ""}`);
+
+    // prepareFigure scrolls the (possibly lazy) figure into view and waits for it
+    // to mount + render. A generous wait covers the dev server compiling a lazy
+    // player chunk on first load (longer than the still-capture default).
+    const rect = await prepareFigure(page, target.index, { waitMs: 30000 });
+
+    // Three capture modes, each building a frame timeline:
+    //  • sweep — explicit checkpoints on a continuous slider (e.g. a chart);
+    //  • scrub — a frame slider (Mol* morph player), driven 0…max;
+    //  • tween — a toggle figure, driven via the virtual clock.
+    const sweepMode = Array.isArray(sweep) && sweep.length > 0;
+    if (sweepMode && !rect.hasRange) {
+      throw new Error(`figure ${target.index} has no slider — --sweep needs a slider chart`);
+    }
+    const { timeline, frameCount } = sweepMode
+      ? await collectSweepFrames(page, target.index, rect, {
+          checkpoints: sweep, fps, checkpointHoldMs, sweepRate, pad, maxWidth,
+          settle: settle ?? 40, loopBack, log,
+        })
+      : rect.hasRange
+      ? await collectScrubFrames(page, target.index, rect, {
+          frames, fps, startHoldMs, endHoldMs, pad, maxWidth,
+          settle: settle ?? 500, playIcon, log,
+        })
+      : await collectTweenFrames(page, target.index, rect, {
+          fps, startHoldMs, midHoldMs: endHoldMs, pad, maxWidth,
+          settle: settle ?? 80, log,
+        });
+
+    timeline.forEach((buf, i) =>
+      fs.writeFileSync(path.join(frameDir, `f${String(i).padStart(4, "0")}.png`), buf)
+    );
+
+    log(`encoding GIF (${timeline.length} frames @ ${fps}fps)…`);
+    await encodeGif({
+      pattern: path.join(frameDir, "f%04d.png"),
+      fps,
+      outFile,
+      log,
+    });
+    const bytes = fs.statSync(outFile).size;
+    log(`  ✓ ${path.basename(outFile)}  ${(bytes / 1024).toFixed(0)} KB`);
+    return { outFile, frames: frameCount, bytes, figureIndex: target.index };
+  } finally {
+    page?.close();
+    proc.kill();
+    if (!keepFrames) fs.rmSync(frameDir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## What

Adds `record` to the article-export toolkit — the moving sibling of `shoot`. It captures an interactive figure's animation as a looping **GIF**, framed identically to the screenshot (same capture region + padding), encoded with ffmpeg `palettegen`/`paletteuse`.

The reusable capture core (`prepareFigure` / `setFigureFrame` / `padAndResize`) is extracted in `capture.mjs` and shared with the still screenshotter, so GIF frames match stills exactly.

## Three capture modes (auto-detected per figure)

Real-time capture tears — a headless screenshot is far slower than an animation frame — so every mode drives the animation deterministically:

- **scrub** — Mol\* morph players: drive the frame slider one step at a time, waiting for the engine to settle. Play-button glyph forced **play → pause → replay** so the loop reads like a real recording.
- **tween** — 2D toggle figures (T↔R switch, BPG doorstop) that animate a `requestAnimationFrame` + `performance.now` tween on a button click: install a **virtual clock** (queue rAF, freeze `performance.now`), click the toggle, advance the clock in even steps and snapshot each — *advance time, let React render, capture*. Captured as a round trip so the loop is seamless. No per-figure pose maths.
- **sweep** — slider charts: walk a continuous slider through checkpoints (raw values or **preset-button labels**, clicked to read where the slider lands), pausing at each and looping back to close the cycle. e.g. `--sweep "lungs,resting tissue,working muscle"` drives pO₂ 95 → 40 → 20.

## A recordings manifest

`pages/essays/<slug>/recordings.json` makes an essay's GIFs declarative and regenerable:

```bash
node scripts/article-export/cli.mjs record hemoglobin              # every recording
node scripts/article-export/cli.mjs record hemoglobin --only bpg-doorstop
node scripts/article-export/cli.mjs record hemoglobin --figure 14 --name foo --sweep "lungs,working muscle"  # ad-hoc
```

Each entry is a spec — `name` plus any `recordFigure` option; `defaults` apply to all; mode is auto-detected, so one manifest mixes morphs, toggles and charts. Adds the hemoglobin manifest (6 figures).

## Notes

- Generated GIFs land in `docs/<slug>/export/`, now gitignored.
- Needs `ffmpeg` on `PATH` (or `FFMPEG_BIN`).
- Verified both paths (batch via `--only`, single ad-hoc) and that the refactor leaves the existing screenshot path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)