### PR TITLE
Fix the navbar's appearance in Safari

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,19 @@ and not the other.**
 - Turbopack drops external `@import url()` in CSS — hence `next/font` in
   `lib/fonts.ts` rather than a stylesheet import.
 
+### The browserslist floor
+
+`package.json` pins `safari >= 15.4` / `ios_saf >= 15.4`. **Don't "modernise"
+that query to `last N versions` or `defaults` alone** — Safari ships 26.x now,
+so those resolve to Safari 26 only, and autoprefixer stops emitting
+`-webkit-backdrop-filter`. Safari didn't take that property unprefixed until
+18.0, so the navbar's frosted glass degrades to a flat translucent pane on every
+Safari and iOS below 18, with a clean build and no warning.
+
+Hand-writing the prefix doesn't rescue it: autoprefixer owns `backdrop-filter`
+and `remove: true` is its default, so it deletes any prefixed declaration its
+targets say is unnecessary. The targets are the only lever.
+
 ## Architecture
 
 Pages Router. Content and figures are parallel trees:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "newt-interactive",
   "version": "0.1.0",
   "private": true,
+  "browserslist": [
+    "defaults",
+    "safari >= 15.4",
+    "ios_saf >= 15.4"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build --webpack",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -31,7 +31,9 @@ function MyApp({ Component, pageProps }) {
     <>
       <Head>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="theme-color" content="#818cf8" />
+        {/* Must equal Tailwind's glass.pane — Safari tints its overscroll
+            strip with this, and drift shows as a band above the navbar. */}
+        <meta name="theme-color" content="#EBE9F9" />
       </Head>
       <TooltipProvider delayDuration={300}>
         <Component {...pageProps} />


### PR DESCRIPTION
Two unrelated Safari bugs in the same strip of screen.

---

## 1. The frosted glass was missing

On Safari the navbar showed no blur — just the flat `bg-glass-pane/80` fill.

### Cause

The repo had no `browserslist` config, so autoprefixer fell back to its own default query. In 2026 that resolves to **`safari 26.4, 26.3` only**, so it judged `-webkit-backdrop-filter` unnecessary and emitted none. The production CSS had zero prefixed declarations:

```css
.backdrop-blur-xl { --tw-backdrop-blur: blur(24px) }
.backdrop-blur-xl, .backdrop-saturate-150 { backdrop-filter: var(--tw-backdrop-blur) … }
```

Safari only took `backdrop-filter` unprefixed in **18.0**. Per caniuse, Safari ≤17.6 and iOS Safari ≤17.7 are `y x` — prefix required. So the blur silently no-ops on Safari 17.6 (where this was found) and on every iOS Safari below 18.

Hand-writing the prefix does **not** work. Autoprefixer manages `backdrop-filter` and `remove: true` is its default, so it deletes any prefixed declaration its targets disown — a `-webkit-backdrop-filter` added via `addUtilities` was stripped straight back out of the build. The targets are the only lever.

### Fix

A `browserslist` floor in `package.json`. Navbar and `tailwind.config.js` are untouched — `backdrop-blur-xl backdrop-saturate-150` now compiles correctly on its own:

```css
.backdrop-blur-xl {
  --tw-backdrop-blur: blur(24px);
  -webkit-backdrop-filter: var(--tw-backdrop-blur) …;
          backdrop-filter: var(--tw-backdrop-blur) …;
}
```

Also recovers the effect for iOS Safari 15–17, likely a larger share of readers than desktop.

`browserslist` in `package.json` also overrides Next's JS transpile targets. Next's built-in default is `safari 12`, so a 15.4 floor is *narrower* — no bundle regression.

---

## 2. Overscrolling flashed an indigo band

Scrolling up past the top of the document showed a bright periwinkle strip above the navbar.

`theme-color` was `#818cf8` — Tailwind's indigo-400, unrelated to anything on the page. Safari paints the area above the document with it. Now set to `glass.pane`, the navbar's own base colour, so the strip reads as an extension of the bar.

The navbar composites that at 80% over paper, giving `#EEECF9` on screen — three points off in two channels, imperceptible.

---

## Notes

`CLAUDE.md` gains a "browserslist floor" section beside the bundler-split warning. Modernising that query to `last N versions` or bare `defaults` re-breaks the blur with a clean build and no warning.

## Testing

- `npm run build` passes, all 17 routes generate.
- Verified `-webkit-backdrop-filter` present in the emitted `.next/static/css` bundle.
- Blur confirmed working in Safari 17.6.
- The `theme-color` change is unverified in Safari — worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)