### PR TITLE
Rewrite the weak meta descriptions

### DIFF
--- a/pages/blocks/circuit-evolution/index.mdx
+++ b/pages/blocks/circuit-evolution/index.mdx
@@ -4,7 +4,7 @@ import CircuitEvolutionSimulation from "../../../interactives/circuit-evolution/
 export const metadata = {
   title: "Circuit Evolution Simulator",
   subtitle: "A basic model of how genetic circuits can evolve",
-  description: "How to simulate circuit evolution",
+  description: "An interactive circuit evolution simulator: mutate a network of NAND gates step by step, or select the fittest of each generation, and watch fitness climb.",
   keywords: "circuit evolution, simulation, graph theory, probability",
   ogImage: "https://www.newtinteractive.com/images/og/generations.png",
   url: "https://www.newtinteractive.com/blocks/circuit-evolution",

--- a/pages/blocks/erdos-renyi-graph/index.mdx
+++ b/pages/blocks/erdos-renyi-graph/index.mdx
@@ -4,7 +4,7 @@ import ErdosRenyiGNMNetworkWithProvider from "../../../interactives/erdos-renyi-
 export const metadata = {
   title: "Erdős-Rényi Graphs",
   subtitle: "How to model random networks",
-  description: "How to model random networks",
+  description: "Generate Erdős-Rényi random graphs in the browser: set the number of nodes and edges in the G(n, M) model and watch the network rewire as you change them.",
   keywords: "Erdős-Rényi graphs, random networks, graph theory, probability",
   ogImage: "https://www.newtinteractive.com/images/og/network.png",
   url: "https://www.newtinteractive.com/blocks/erdos-renyi-graph",

--- a/pages/notes/threejs-journey/index.mdx
+++ b/pages/notes/threejs-journey/index.mdx
@@ -16,7 +16,7 @@ export const metadata = {
       </a>
     </>
   ),
-  description: "Learn about ThreeJS concepts with interactive examples and playgrounds.",
+  description: "Notes from a Three.js course, with live examples you can edit: animating a mesh each frame, camera types and controls, and writing your first GLSL shaders.",
   keywords: "ThreeJS, 3D graphics, web development, animations, cameras, shaders, interactive learning",
   ogImage: "https://www.newtinteractive.com/images/og/wireframe.png",
   url: "https://www.newtinteractive.com/notes/threejs-journey",

--- a/pages/series/systems-biology/autoregulation-1.mdx
+++ b/pages/series/systems-biology/autoregulation-1.mdx
@@ -8,7 +8,7 @@ import { FiInfo, FiChevronDown } from "react-icons/fi";
 export const metadata = {
   title: "Autoregulation as a Network Motif",
   subtitle: "Random networks, finding patterns, and genes that regulate their own expression",
-  description: "Explore the concepts of network motifs, random networks and autoregulation in systems biology.",
+  description: "Compare E. coli's transcription network with an Erdős-Rényi random graph to see why autoregulation counts as a network motif, with an interactive generator.",
   keywords: "network motifs, random networks, autoregulation, gene expression, transcription factors, systems biology, cell signaling",
   ogImage: "https://www.newtinteractive.com/images/og/network-layered.png",
   url: "https://www.newtinteractive.com/series/systems-biology/autoregulation-1",

--- a/pages/series/systems-biology/autoregulation-2.mdx
+++ b/pages/series/systems-biology/autoregulation-2.mdx
@@ -8,7 +8,7 @@ import {
 export const metadata = {
   title: "Dynamics of Negative Autoregulation",
   subtitle: "How self-repression speeds up the response time of gene circuits",
-  description: "How self-repression speeds up the response time of gene circuits",
+  description: "How self-repression speeds up a gene circuit: derive the response time of negative autoregulation and compare it with simple regulation in interactive charts.",
   keywords: "network motifs, random networks, autoregulation, gene expression, transcription factors, systems biology, cell signaling",
   ogImage: "https://www.newtinteractive.com/images/og/network-layered.png",
   url: "https://www.newtinteractive.com/series/systems-biology/autoregulation-2",

--- a/pages/series/systems-biology/index.tsx
+++ b/pages/series/systems-biology/index.tsx
@@ -10,7 +10,8 @@ const piece = getPiece(HREF);
 const metadata = {
   title: piece.title,
   subtitle: piece.subtitle,
-  description: "Explore interactive explainers on systems biology concepts",
+  description:
+    "Work through systems biology with interactive explainers: transcription networks, activators and repressors, response time, and negative autoregulation.",
   keywords:
     "systems biology, interactive explainers, transcription networks, gene expression, biological systems",
   ogImage: "https://www.newtinteractive.com/images/og/network-layered.png",

--- a/pages/series/systems-biology/transcription-network-basics-3.mdx
+++ b/pages/series/systems-biology/transcription-network-basics-3.mdx
@@ -4,7 +4,7 @@ import { StepFunctionTutorial, ProteinDecayResponseTimeTutorial, ProteinAccumula
 export const metadata = {
   title: "Transcription Network Basics: Part Three",
   subtitle: "Logic approximations, handling multiple inputs, and the dynamics of transcription networks",
-  description: "Learn how cells respond to signals over time, and how quickly they can do so.",
+  description: "Approximate input functions with logic gates, handle genes with multiple inputs, and see how fast a cell responds to a signal in interactive dynamics charts.",
   keywords: "transcription networks, dynamics, response time, systems biology",
   ogImage: "https://www.newtinteractive.com/images/og/network-layered.png",
   url: "https://www.newtinteractive.com/series/systems-biology/transcription-network-basics-3",


### PR DESCRIPTION
Follow-up to #49. That PR built the SEO plumbing; this fills in the descriptions it renders.

Seven pages had descriptions too short to fill a search result — most were the subtitle repeated verbatim, one at 28 characters. Each is now 144-158 characters and leads with what the reader can *do* on the page, since being interactive is the thing that distinguishes these results from the reference sites they appear beside. `keywords` is untouched; Google ignores it.

| page | old | new |
|---|---|---|
| `blocks/circuit-evolution` | 33 | 155 |
| `blocks/erdos-renyi-graph` | 28 | 154 |
| `series/systems-biology` | 57 | 152 |
| `series/systems-biology/autoregulation-2` | 64 | 158 |
| `series/systems-biology/transcription-network-basics-3` | 77 | 157 |
| `notes/threejs-journey` | 70 | 155 |
| `series/systems-biology/autoregulation-1` | 94 | 156 |

**Circuit evolution is the only one with something to gain soon.** It ranks 7.1 for "circuit evolution" and 7.4 for "circuit evolve" — page one — and converts at 0% and 1.9% against an expected 3-5%. Everything else sits at position 26-61, where a better description changes nothing until the ranking moves; those edits are groundwork.

The framing follows the strongest signal in Search Console: "dna 3d model interactive" pulls 9.1% CTR from position 14.7, roughly 5x expected. When someone explicitly wants an interactive, this site's result already wins — so the descriptions say so plainly rather than describing the topic.

Two judgement calls worth flagging:

- **threejs-journey** stays honest about being course notes and doesn't chase the "three js journey" queries (~750 impressions, 3 clicks). That's Bruno Simon's course brand; those searchers want the official site, not a notes page.
- **autoregulation-1** was flagged as possibly inaccurate for mentioning random networks. It isn't — the page derives the expected self-arrow count for an Erdős-Rényi network and embeds the generator. It was just generic, so the new one names the E. coli comparison.

## Verification

`npm run build` passes. Served the production build and curled each page: `description`, `og:description` and `twitter:description` all render the new text, and the accents on Erdős-Rényi survive the pipeline.

Descriptions move CTR, not position — worth judging on CTR at stable position, 2-4 weeks out. Baseline, 12 months to 2026-07-19: 152 clicks / 9.72K impressions / 1.6% CTR / position 16.9; circuit evolution 108 impressions, 1 click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)